### PR TITLE
Bugfix for MacOS installs from pip

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -63,16 +63,17 @@ macOS 10.13 (High Sierra) and 10.14 (Mojave)
 .. note::
    Supported from adcc 0.13.2.
 
-.. note::
-   TODO This section needs more details!
-
+0. **Homebrew:**
+   Support for macOS currently requires the `Homebrew <https://brew.sh>`_ package manager
+   and a recent version of ``gcc`` (e.g. ``gcc@9``). Hopefully, we will support ``clang`` in the future.
+   
 1. **adcc:**
    Install from `PyPi <https://pypi.org>`_, using ``pip``:
 
    .. code-block:: shell
 
       pip install pybind11     # Install pybind11 first to suppress some error messages
-      pip install adcc
+      CXX=g++-9 CC=gcc-9 pip install adcc   # Install adcc using the correct compiler for Python bindings
 
 .. _install-hostprogram:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -60,9 +60,8 @@ macOS 10.13 (High Sierra) and 10.14 (Mojave)
    only covers High Sierra and Mojave.
    We would love to hear your feedback in case things fail.
 
-   In adcc 0.13.1 there is a known bug for the pip installation
-   on macOS, causing it to produce a corrupt installation,
-   for a workaround, see https://github.com/adc-connect/adcc/pull/1.
+.. note::
+   Supported from adcc 0.13.2.
 
 .. note::
    TODO This section needs more details!

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -60,6 +60,10 @@ macOS 10.13 (High Sierra) and 10.14 (Mojave)
    only covers High Sierra and Mojave.
    We would love to hear your feedback in case things fail.
 
+   In adcc 0.13.1 there is a known bug for the pip installation
+   on macOS, causing it to produce a corrupt installation,
+   for a workaround, see https://github.com/adc-connect/adcc/pull/1.
+
 .. note::
    TODO This section needs more details!
 

--- a/extension/AdcCore.py
+++ b/extension/AdcCore.py
@@ -157,15 +157,17 @@ class AdcCore:
                        "".format(version, get_platform(), base_url))
                 if 400 <= status_code < 500:
                     # Either an unsupported version or an error on our end
-                    msg += (" This should not have happened and either this means your platform is"
-                            " unsupported or that there is a bug. Please check the adcc installation"
-                            " instructions and if in doubt, please open an issue on github.")
+                    msg += (" This should not have happened and either this means your"
+                            " platform / OS / architecture is unsupported or that there"
+                            " is a bug in adcc. Please check the adcc installation"
+                            " instructions (https://adc-connect.org/installation.html)"
+                            " and if in doubt, please open an issue on github.")
                 raise RuntimeError(msg)
 
             # Delete the old files
             for fglob in self.file_globs:
-                for fn in glob.glob(fglob):
-                    os.remove(self.install_dir + "/" + fglob)
+                for fn in glob.glob(self.install_dir + "/" + fglob):
+                    os.remove(fn)
 
             # Change to installation directory
             olddir = os.getcwd()

--- a/extension/AdcCore.py
+++ b/extension/AdcCore.py
@@ -28,6 +28,7 @@ import tempfile
 import subprocess
 import distutils.util
 
+from distutils import log
 from os.path import join
 
 
@@ -167,6 +168,7 @@ class AdcCore:
             # Delete the old files
             for fglob in self.file_globs:
                 for fn in glob.glob(self.install_dir + "/" + fglob):
+                    log.info("Removing old adccore file {}".format(fn))
                     os.remove(fn)
 
             # Change to installation directory

--- a/extension/AdcCore.py
+++ b/extension/AdcCore.py
@@ -61,10 +61,10 @@ def request_urllib(url, filename):
 class AdcCore:
     def __init__(self):
         this_dir = os.path.dirname(__file__)
-        top_dir = os.path.abspath(join(this_dir, ".."))
-        self.source_dir = join(top_dir, "adccore")
+        self.top_dir = os.path.abspath(join(this_dir, ".."))
+        self.source_dir = join(self.top_dir, "adccore")
         self.install_dir = join(this_dir, "adccore")
-        self.library_dir = join(top_dir, "adcc", "lib")
+        self.library_dir = join(self.top_dir, "adcc", "lib")
         self.include_dir = join(self.install_dir, "include")
         self.config_path = join(self.install_dir, "adccore_config.json")
 
@@ -118,21 +118,22 @@ class AdcCore:
     @property
     def file_globs(self):
         """
-        Return the file globs to be applied relative to the installation directory
-        in order to obtain all files relevant for the binary distribution of adccore.
+        Return the file globs to be applied relative to the top directory of the
+        repository in order to obtain all files relevant for the binary distribution
+        of adccore.
         """
         return [
-            "adccore_config.json",
-            "include/ctx/*.hh",
-            "include/adcc/*.hh",
-            "include/adcc/*/*.hh",
-            "lib/libadccore.so",
-            "lib/libadccore.*.dylib",
-            "lib/libadccore.dylib",
-            "lib/libstdc++.so.*",
-            "lib/libc++.so.*",
-            "lib/libadccore_LICENSE",
-            "lib/libadccore_thirdparty/ctx/*",
+            self.install_dir + "/adccore_config.json",
+            self.install_dir + "/include/ctx/*.hh",
+            self.install_dir + "/include/adcc/*.hh",
+            self.install_dir + "/include/adcc/*/*.hh",
+            self.library_dir + "/libadccore.so",
+            self.library_dir + "/libadccore.*.dylib",
+            self.library_dir + "/libadccore.dylib",
+            self.library_dir + "/libstdc++.so.*",
+            self.library_dir + "/libc++.so.*",
+            self.library_dir + "/libadccore_LICENSE",
+            self.library_dir + "/libadccore_thirdparty/ctx/*",
         ]
 
     def get_tarball_name(self, version=None, postfix=None):
@@ -167,13 +168,13 @@ class AdcCore:
 
             # Delete the old files
             for fglob in self.file_globs:
-                for fn in glob.glob(self.install_dir + "/" + fglob):
+                for fn in glob.glob(fglob):
                     log.info("Removing old adccore file {}".format(fn))
                     os.remove(fn)
 
             # Change to installation directory
             olddir = os.getcwd()
-            os.chdir(self.install_dir)
+            os.chdir(self.top_dir)
             subprocess.run(["tar", "xf", local], check=True)
             os.chdir(olddir)
 

--- a/scripts/upload_core.py
+++ b/scripts/upload_core.py
@@ -54,10 +54,11 @@ def make_tarball(adccore, postfix=None):
 
     os.makedirs("dist", exist_ok=True)
     olddir = os.getcwd()
-    os.chdir(adccore.install_dir)
+    os.chdir(adccore.top_dir)
     filelist = []
     for globstr in adccore.file_globs:
-        filelist += glob.glob(globstr)
+        relglob = os.path.relpath(globstr, adccore.top_dir)
+        filelist += glob.glob(relglob)
     subprocess.run(["tar", "cvzf", fullpath] + filelist)
     os.chdir(olddir)
     return "dist/" + filename

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ except ImportError:
 
 # Version of the python bindings and adcc python package.
 __version__ = '0.13.1'
-adccore_version = ("0.13.1", "")  # (base version, unstable postfix)
+adccore_version = ("0.13.2", "")  # (base version, unstable postfix)
 
 
 def get_adccore_data():


### PR DESCRIPTION
There was an issue properly replacing the linux binaries shipped with with the downloaded MacOS binaries. This should be fixed by this PR. I have made a test upload with the proposed fix at <https://get.adc-connect.org/adcc-0.13.1.tar.gz>.

@maxscheurer Could you test that?