### PR TITLE
Drop exporting ctx symbols

### DIFF
--- a/extension/export_MoSpaces.cc
+++ b/extension/export_MoSpaces.cc
@@ -112,8 +112,6 @@ void export_MoSpaces(py::module& m) {
               "Contains for each orbital space the mapping from each *block* used inside "
               "the space to the spin it correspond to ('a' is alpha and 'b' is beta)")
         //
-        .def("to_ctx", &MoSpaces::to_ctx)
-        //
         // TODO describe function
         ;
 }

--- a/extension/export_ReferenceState.cc
+++ b/extension/export_ReferenceState.cc
@@ -169,8 +169,6 @@ void export_ReferenceState(py::module& m) {
               [](const ReferenceState& self) { return convert_timer(self.timer()); },
               "Obtain the timer object of this class.")
         //
-        .def("to_ctx", &ReferenceState::to_ctx)
-        //
         ;
 }
 


### PR DESCRIPTION
The `to_ctx` functions are currently not needed and dropping them allows to transparently restructure adccore with respect to the CtxMap functionality without breaking the interface to adcc.