### PR TITLE
[WIP] Clang support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,6 @@ jobs:
     - os: osx
       language: script
       osx_image: xcode11.1  # macos 10.14
-      env: [CC=gcc-9, CXX=g++-9]
 
 # TODO Does not work at the moment, see the travis output
 # https://travis-ci.org/adc-connect/adcc/jobs/603309015#L2647

--- a/adcc/backends/available_backends.py
+++ b/adcc/backends/available_backends.py
@@ -34,7 +34,7 @@ def is_module_available(module):
 
 status = {
     "pyscf": is_module_available("pyscf"),
-    "psi4": is_module_available("psi4"),
+    "psi4": is_module_available("psi4") and is_module_available("psi4.core"),
     "veloxchem": is_module_available("veloxchem"),
     "molsturm": is_module_available("molsturm"),
 }

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -61,22 +61,20 @@ macOS 10.13 (High Sierra) and 10.14 (Mojave)
    macOS support is still experimental and so far
    only covers High Sierra and Mojave.
    We would love to hear your feedback in case things fail.
+   We are currently working on deploying adcc to `Anaconda <https://anaconda.org>`_.
 
 .. note::
-   Supported from adcc 0.13.2.
-
-0. **Homebrew:**
-   Support for macOS currently requires the `Homebrew <https://brew.sh>`_ package manager
-   and a recent version of ``gcc`` (e.g. ``brew install gcc@9``).
-   Hopefully, we will support ``clang`` in the future.
-   
+   The installation on macOS requires a ``clang`` compiler.
+   Make sure to have XCode and the command line tools installed.
+   ``clang`` is supported from adcc 0.13.2.
+ 
 1. **adcc:**
    Install from `PyPi <https://pypi.org>`_, using ``pip``:
 
    .. code-block:: shell
 
       pip install pybind11     # Install pybind11 first to suppress some error messages
-      CXX=g++-9 CC=gcc-9 pip install adcc   # Install adcc using the correct compiler for Python bindings
+      pip install adcc   # Install adcc
 
 .. _install-hostprogram:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -63,10 +63,9 @@ macOS 10.13 (High Sierra) and 10.14 (Mojave)
    We would love to hear your feedback in case things fail.
    We are currently working on deploying adcc to `Anaconda <https://anaconda.org>`_.
 
-.. note::
-   The installation on macOS requires a ``clang`` compiler.
-   Make sure to have XCode and the command line tools installed.
-   ``clang`` is supported from adcc 0.13.2.
+
+The installation on macOS requires a ``clang`` compiler.
+Make sure to have XCode and the command line tools installed.
  
 1. **adcc:**
    Install from `PyPi <https://pypi.org>`_, using ``pip``:

--- a/extension/convert_timer.cc
+++ b/extension/convert_timer.cc
@@ -52,4 +52,3 @@ py::object convert_timer(const Timer& timer) {
 
 }  // namespace py_iface
 }  // namespace adcc
-

--- a/extension/export_CachingPolicy.cc
+++ b/extension/export_CachingPolicy.cc
@@ -54,4 +54,3 @@ void export_CachingPolicy(py::module& m) {
 
 }  // namespace py_iface
 }  // namespace adcc
-

--- a/extension/export_HartreeFockProvider.cc
+++ b/extension/export_HartreeFockProvider.cc
@@ -67,7 +67,7 @@ class HartreeFockProvider : public HartreeFockSolution_i {
                                ").");
     }
     py::memoryview memview(py::buffer_info(buffer, n_orbs));
-    fill_occupation_f(py::array({n_orbs}, buffer, memview));
+    fill_occupation_f(py::array({{n_orbs}}, buffer, memview));
   }
 
   void orben_f(scalar_type* buffer, size_t size) const override {
@@ -79,7 +79,7 @@ class HartreeFockProvider : public HartreeFockSolution_i {
                                ").");
     }
     py::memoryview memview(py::buffer_info(buffer, n_orbs));
-    fill_orben_f(py::array({n_orbs}, buffer, memview));
+    fill_orben_f(py::array({{n_orbs}}, buffer, memview));
   }
 
   void orbcoeff_fb(scalar_type* buffer, size_t size) const override {
@@ -303,10 +303,10 @@ class PyHartreeFockProvider : public HartreeFockProvider {
   void fill_fock_ff(py::tuple slices, py::array out) const override {
     PYBIND11_OVERLOAD_PURE(void, HartreeFockProvider, fill_fock_ff, slices, out);
   }
-  void fill_eri_ffff(py::tuple slices, py::array out) const {
+  void fill_eri_ffff(py::tuple slices, py::array out) const override {
     PYBIND11_OVERLOAD_PURE(void, HartreeFockProvider, fill_eri_ffff, slices, out);
   }
-  void fill_eri_phys_asym_ffff(py::tuple slices, py::array out) const {
+  void fill_eri_phys_asym_ffff(py::tuple slices, py::array out) const override {
     PYBIND11_OVERLOAD_PURE(void, HartreeFockProvider, fill_eri_phys_asym_ffff, slices,
                            out);
   }
@@ -381,11 +381,13 @@ void export_HartreeFockProvider(py::module& m) {
         //      and maybe should be removed for this reason
         .def_property_readonly("n_alpha",
                                [](const adcc::HartreeFockSolution_i& self) {
-                                 return count_electrons(self, /* count_beta = */ false);
+                                 return count_electrons(self,
+                                                        /* count_beta = */ false);
                                })
         .def_property_readonly("n_beta",
                                [](const adcc::HartreeFockSolution_i& self) {
-                                 return count_electrons(self, /* count_beta = */ true);
+                                 return count_electrons(self,
+                                                        /* count_beta = */ true);
                                })
         .def_property_readonly("conv_tol", &HartreeFockSolution_i::conv_tol)
         .def_property_readonly("restricted", &HartreeFockSolution_i::restricted)
@@ -408,79 +410,110 @@ void export_HartreeFockProvider(py::module& m) {
   py::class_<HartreeFockProvider, std::shared_ptr<HartreeFockProvider>,
              PyHartreeFockProvider>(
         m, "HartreeFockProvider", hfdata_i,
-        "Abstract class defining the interface for passing data from the host program to "
-        "adcc. All functions of this class need to be overwritten explicitly from "
-        "python.\nIn the remaining documentation we denote with `nf` the value returned "
+        "Abstract class defining the interface for passing data from the host "
+        "program to "
+        "adcc. All functions of this class need to be overwritten explicitly "
+        "from "
+        "python.\nIn the remaining documentation we denote with `nf` the value "
+        "returned "
         "by `get_n_orbs_alpha()` and with `nb` the value returned by "
         "`get_nbas()`.")
         .def(py::init<>())
         //
         .def("get_conv_tol", &HartreeFockProvider::get_conv_tol,
-             "Returns the tolerance value used for SCF convergence. Should be roughly "
+             "Returns the tolerance value used for SCF convergence. Should be "
+             "roughly "
              "equivalent to the l2 norm of the Pulay error.")
         .def("get_restricted", &HartreeFockProvider::get_restricted,
              "Return *True* for a restricted SCF calculation, *False* otherwise.")
         .def("get_energy_scf", &HartreeFockProvider::get_energy_scf,
-             "Returns the final total SCF energy (sum of electronic and nuclear terms.")
+             "Returns the final total SCF energy (sum of electronic and nuclear "
+             "terms.")
         .def("get_spin_multiplicity", &HartreeFockProvider::get_spin_multiplicity,
-             "Returns the spin multiplicity of the HF ground state. A value of 0* (for "
+             "Returns the spin multiplicity of the HF ground state. A value of "
+             "0* (for "
              "unknown) should be supplied for unrestricted calculations.")
         .def("get_n_orbs_alpha", &HartreeFockProvider::get_n_orbs_alpha,
-             "Returns the number of HF *spin* orbitals of alpha spin. It is assumed the "
-             "same number of beta spin orbitals are used. This value is abbreviated by "
+             "Returns the number of HF *spin* orbitals of alpha spin. It is "
+             "assumed the "
+             "same number of beta spin orbitals are used. This value is "
+             "abbreviated by "
              "`nf` in the documentation.")
         .def("get_n_bas", &HartreeFockProvider::get_n_bas,
-             "Returns the number of *spatial* one-electron basis functions. This value "
+             "Returns the number of *spatial* one-electron basis functions. This "
+             "value "
              "is abbreviated by `nb` in the documentation.")
         .def("get_nuclear_multipole", &HartreeFockProvider::get_nuclear_multipole,
-             "Returns the nuclear multipole of the requested order. For `0` returns the "
-             "total nuclear charge as an array of size 1, for `1` returns the nuclear "
+             "Returns the nuclear multipole of the requested order. For `0` "
+             "returns the "
+             "total nuclear charge as an array of size 1, for `1` returns the "
+             "nuclear "
              "dipole moment as an array of size 3.")
         //
         .def("fill_occupation_f", &HartreeFockProvider::fill_orben_f,
-             "Fill the passed numpy array of size `(2 * nf, )` with the occupation "
+             "Fill the passed numpy array of size `(2 * nf, )` with the "
+             "occupation "
              "number for each SCF orbital.")
         .def("fill_orben_f", &HartreeFockProvider::fill_orben_f,
-             "Fill the passed numpy array of size `(2 * nf, )` with the SCF orbital "
+             "Fill the passed numpy array of size `(2 * nf, )` with the SCF "
+             "orbital "
              "energies.")
         .def("fill_orbcoeff_fb", &HartreeFockProvider::fill_orbcoeff_fb,
-             "Fill the passed numpy array of size `(2 * nf, nb)` with the SCF orbital "
-             "coefficients, i.e. the uniform transform from the one-particle basis to "
+             "Fill the passed numpy array of size `(2 * nf, nb)` with the SCF "
+             "orbital "
+             "coefficients, i.e. the uniform transform from the one-particle "
+             "basis to "
              "the molecular orbitals.")
         .def("fill_fock_ff", &HartreeFockProvider::fill_fock_ff,
-             "Fill the passed numpy array `arg1` with a part of the Fock matrix in the "
-             "molecular orbital basis. The block to store is specified by the provided "
-             "tuple of ranges `arg0`, which gives the range of indices to place into the "
+             "Fill the passed numpy array `arg1` with a part of the Fock matrix "
+             "in the "
+             "molecular orbital basis. The block to store is specified by the "
+             "provided "
+             "tuple of ranges `arg0`, which gives the range of indices to place "
+             "into the "
              "buffer along each of the axis. The index counting is done in spin "
              "orbitals, so the full range in each axis is `range(0, 2 * nf)`. The "
-             "implementation should not assume that the alpha-beta and beta-alpha blocks "
+             "implementation should not assume that the alpha-beta and beta-alpha "
+             "blocks "
              "are not accessed even though they are zero by spin symmetry.")
         .def("fill_eri_ffff", &HartreeFockProvider::fill_eri_ffff,
-             "Fill the passed numpy array `arg1` with a part of the electron-repulsion "
+             "Fill the passed numpy array `arg1` with a part of the "
+             "electron-repulsion "
              "integral tensor in the molecular orbital basis. "
-             "The indexing convention is the chemist's notation, i.e. the index tuple "
+             "The indexing convention is the chemist's notation, i.e. the index "
+             "tuple "
              "`(i,j,k,l)` refers to the integral :math:`(ij|kl)`. "
              "The block to store is specified by the provided "
-             "tuple of ranges `arg0`, which gives the range of indices to place into the "
+             "tuple of ranges `arg0`, which gives the range of indices to place "
+             "into the "
              "buffer along each of the axis. The index counting is done in spin "
              "orbitals, so the full range in each axis is `range(0, 2 * nf)`.")
         .def("fill_eri_phys_asym_ffff", &HartreeFockProvider::fill_eri_phys_asym_ffff,
-             "Fill the passed numpy array `arg1` with a part of the **antisymmetrised** "
+             "Fill the passed numpy array `arg1` with a part of the "
+             "**antisymmetrised** "
              "electron-repulsion integral tensor in the molecular orbital basis. "
-             "The indexing convention is the physicist's notation, i.e. the index tuple "
-             "`(i,j,k,l)` refers to the integral :math:`\\langle ij||kl \\rangle`. "
+             "The indexing convention is the physicist's notation, i.e. the "
+             "index tuple "
+             "`(i,j,k,l)` refers to the integral :math:`\\langle ij||kl "
+             "\\rangle`. "
              "The block to store is specified by the provided "
-             "tuple of ranges `arg0`, which gives the range of indices to place into the "
+             "tuple of ranges `arg0`, which gives the range of indices to place "
+             "into the "
              "buffer along each of the axis. The index counting is done in spin "
              "orbitals, so the full range in each axis is `range(0, 2 * nf)`.")
         .def("has_eri_phys_asym_ffff", &HartreeFockProvider::has_eri_phys_asym_ffff,
-             "Returns whether `fill_eri_phys_asym_ffff` function is implemented and "
-             "should be used(*True*) or whether antisymmetrisation should be done inside "
+             "Returns whether `fill_eri_phys_asym_ffff` function is implemented "
+             "and "
+             "should be used(*True*) or whether antisymmetrisation should be "
+             "done inside "
              "adcc starting from the `fill_eri_ffff` function (*False*)")
         .def("flush_cache", &HartreeFockProvider::flush_cache,
-             "This function is called to signal that potential cached data could now be "
-             "flushed to save memory or other resources.\nThis can be used to purge e.g. "
-             "intermediates for the computation of electron-repulsion integral tensor "
+             "This function is called to signal that potential cached data could "
+             "now be "
+             "flushed to save memory or other resources.\nThis can be used to "
+             "purge e.g. "
+             "intermediates for the computation of electron-repulsion integral "
+             "tensor "
              "data.")
         //
         ;

--- a/extension/export_HartreeFockProvider.cc
+++ b/extension/export_HartreeFockProvider.cc
@@ -381,13 +381,11 @@ void export_HartreeFockProvider(py::module& m) {
         //      and maybe should be removed for this reason
         .def_property_readonly("n_alpha",
                                [](const adcc::HartreeFockSolution_i& self) {
-                                 return count_electrons(self,
-                                                        /* count_beta = */ false);
+                                 return count_electrons(self, /* count_beta = */ false);
                                })
         .def_property_readonly("n_beta",
                                [](const adcc::HartreeFockSolution_i& self) {
-                                 return count_electrons(self,
-                                                        /* count_beta = */ true);
+                                 return count_electrons(self, /* count_beta = */ true);
                                })
         .def_property_readonly("conv_tol", &HartreeFockSolution_i::conv_tol)
         .def_property_readonly("restricted", &HartreeFockSolution_i::restricted)
@@ -410,110 +408,79 @@ void export_HartreeFockProvider(py::module& m) {
   py::class_<HartreeFockProvider, std::shared_ptr<HartreeFockProvider>,
              PyHartreeFockProvider>(
         m, "HartreeFockProvider", hfdata_i,
-        "Abstract class defining the interface for passing data from the host "
-        "program to "
-        "adcc. All functions of this class need to be overwritten explicitly "
-        "from "
-        "python.\nIn the remaining documentation we denote with `nf` the value "
-        "returned "
+        "Abstract class defining the interface for passing data from the host program to "
+        "adcc. All functions of this class need to be overwritten explicitly from "
+        "python.\nIn the remaining documentation we denote with `nf` the value returned "
         "by `get_n_orbs_alpha()` and with `nb` the value returned by "
         "`get_nbas()`.")
         .def(py::init<>())
         //
         .def("get_conv_tol", &HartreeFockProvider::get_conv_tol,
-             "Returns the tolerance value used for SCF convergence. Should be "
-             "roughly "
+             "Returns the tolerance value used for SCF convergence. Should be roughly "
              "equivalent to the l2 norm of the Pulay error.")
         .def("get_restricted", &HartreeFockProvider::get_restricted,
              "Return *True* for a restricted SCF calculation, *False* otherwise.")
         .def("get_energy_scf", &HartreeFockProvider::get_energy_scf,
-             "Returns the final total SCF energy (sum of electronic and nuclear "
-             "terms.")
+             "Returns the final total SCF energy (sum of electronic and nuclear terms.")
         .def("get_spin_multiplicity", &HartreeFockProvider::get_spin_multiplicity,
-             "Returns the spin multiplicity of the HF ground state. A value of "
-             "0* (for "
+             "Returns the spin multiplicity of the HF ground state. A value of 0* (for "
              "unknown) should be supplied for unrestricted calculations.")
         .def("get_n_orbs_alpha", &HartreeFockProvider::get_n_orbs_alpha,
-             "Returns the number of HF *spin* orbitals of alpha spin. It is "
-             "assumed the "
-             "same number of beta spin orbitals are used. This value is "
-             "abbreviated by "
+             "Returns the number of HF *spin* orbitals of alpha spin. It is assumed the "
+             "same number of beta spin orbitals are used. This value is abbreviated by "
              "`nf` in the documentation.")
         .def("get_n_bas", &HartreeFockProvider::get_n_bas,
-             "Returns the number of *spatial* one-electron basis functions. This "
-             "value "
+             "Returns the number of *spatial* one-electron basis functions. This value "
              "is abbreviated by `nb` in the documentation.")
         .def("get_nuclear_multipole", &HartreeFockProvider::get_nuclear_multipole,
-             "Returns the nuclear multipole of the requested order. For `0` "
-             "returns the "
-             "total nuclear charge as an array of size 1, for `1` returns the "
-             "nuclear "
+             "Returns the nuclear multipole of the requested order. For `0` returns the "
+             "total nuclear charge as an array of size 1, for `1` returns the nuclear "
              "dipole moment as an array of size 3.")
         //
         .def("fill_occupation_f", &HartreeFockProvider::fill_orben_f,
-             "Fill the passed numpy array of size `(2 * nf, )` with the "
-             "occupation "
+             "Fill the passed numpy array of size `(2 * nf, )` with the occupation "
              "number for each SCF orbital.")
         .def("fill_orben_f", &HartreeFockProvider::fill_orben_f,
-             "Fill the passed numpy array of size `(2 * nf, )` with the SCF "
-             "orbital "
+             "Fill the passed numpy array of size `(2 * nf, )` with the SCF orbital "
              "energies.")
         .def("fill_orbcoeff_fb", &HartreeFockProvider::fill_orbcoeff_fb,
-             "Fill the passed numpy array of size `(2 * nf, nb)` with the SCF "
-             "orbital "
-             "coefficients, i.e. the uniform transform from the one-particle "
-             "basis to "
+             "Fill the passed numpy array of size `(2 * nf, nb)` with the SCF orbital "
+             "coefficients, i.e. the uniform transform from the one-particle basis to "
              "the molecular orbitals.")
         .def("fill_fock_ff", &HartreeFockProvider::fill_fock_ff,
-             "Fill the passed numpy array `arg1` with a part of the Fock matrix "
-             "in the "
-             "molecular orbital basis. The block to store is specified by the "
-             "provided "
-             "tuple of ranges `arg0`, which gives the range of indices to place "
-             "into the "
+             "Fill the passed numpy array `arg1` with a part of the Fock matrix in the "
+             "molecular orbital basis. The block to store is specified by the provided "
+             "tuple of ranges `arg0`, which gives the range of indices to place into the "
              "buffer along each of the axis. The index counting is done in spin "
              "orbitals, so the full range in each axis is `range(0, 2 * nf)`. The "
-             "implementation should not assume that the alpha-beta and beta-alpha "
-             "blocks "
+             "implementation should not assume that the alpha-beta and beta-alpha blocks "
              "are not accessed even though they are zero by spin symmetry.")
         .def("fill_eri_ffff", &HartreeFockProvider::fill_eri_ffff,
-             "Fill the passed numpy array `arg1` with a part of the "
-             "electron-repulsion "
+             "Fill the passed numpy array `arg1` with a part of the electron-repulsion "
              "integral tensor in the molecular orbital basis. "
-             "The indexing convention is the chemist's notation, i.e. the index "
-             "tuple "
+             "The indexing convention is the chemist's notation, i.e. the index tuple "
              "`(i,j,k,l)` refers to the integral :math:`(ij|kl)`. "
              "The block to store is specified by the provided "
-             "tuple of ranges `arg0`, which gives the range of indices to place "
-             "into the "
+             "tuple of ranges `arg0`, which gives the range of indices to place into the "
              "buffer along each of the axis. The index counting is done in spin "
              "orbitals, so the full range in each axis is `range(0, 2 * nf)`.")
         .def("fill_eri_phys_asym_ffff", &HartreeFockProvider::fill_eri_phys_asym_ffff,
-             "Fill the passed numpy array `arg1` with a part of the "
-             "**antisymmetrised** "
+             "Fill the passed numpy array `arg1` with a part of the **antisymmetrised** "
              "electron-repulsion integral tensor in the molecular orbital basis. "
-             "The indexing convention is the physicist's notation, i.e. the "
-             "index tuple "
-             "`(i,j,k,l)` refers to the integral :math:`\\langle ij||kl "
-             "\\rangle`. "
+             "The indexing convention is the physicist's notation, i.e. the index tuple "
+             "`(i,j,k,l)` refers to the integral :math:`\\langle ij||kl \\rangle`. "
              "The block to store is specified by the provided "
-             "tuple of ranges `arg0`, which gives the range of indices to place "
-             "into the "
+             "tuple of ranges `arg0`, which gives the range of indices to place into the "
              "buffer along each of the axis. The index counting is done in spin "
              "orbitals, so the full range in each axis is `range(0, 2 * nf)`.")
         .def("has_eri_phys_asym_ffff", &HartreeFockProvider::has_eri_phys_asym_ffff,
-             "Returns whether `fill_eri_phys_asym_ffff` function is implemented "
-             "and "
-             "should be used(*True*) or whether antisymmetrisation should be "
-             "done inside "
+             "Returns whether `fill_eri_phys_asym_ffff` function is implemented and "
+             "should be used(*True*) or whether antisymmetrisation should be done inside "
              "adcc starting from the `fill_eri_ffff` function (*False*)")
         .def("flush_cache", &HartreeFockProvider::flush_cache,
-             "This function is called to signal that potential cached data could "
-             "now be "
-             "flushed to save memory or other resources.\nThis can be used to "
-             "purge e.g. "
-             "intermediates for the computation of electron-repulsion integral "
-             "tensor "
+             "This function is called to signal that potential cached data could now be "
+             "flushed to save memory or other resources.\nThis can be used to purge e.g. "
+             "intermediates for the computation of electron-repulsion integral tensor "
              "data.")
         //
         ;

--- a/extension/export_HartreeFockProvider.cc
+++ b/extension/export_HartreeFockProvider.cc
@@ -67,7 +67,7 @@ class HartreeFockProvider : public HartreeFockSolution_i {
                                ").");
     }
     py::memoryview memview(py::buffer_info(buffer, n_orbs));
-    fill_occupation_f(py::array({{n_orbs}}, buffer, memview));
+    fill_occupation_f(py::array(std::vector<ssize_t>{n_orbs}, buffer, memview));
   }
 
   void orben_f(scalar_type* buffer, size_t size) const override {
@@ -79,7 +79,7 @@ class HartreeFockProvider : public HartreeFockSolution_i {
                                ").");
     }
     py::memoryview memview(py::buffer_info(buffer, n_orbs));
-    fill_orben_f(py::array({{n_orbs}}, buffer, memview));
+    fill_orben_f(py::array(std::vector<ssize_t>{n_orbs}, buffer, memview));
   }
 
   void orbcoeff_fb(scalar_type* buffer, size_t size) const override {

--- a/extension/export_MoSpaces.cc
+++ b/extension/export_MoSpaces.cc
@@ -117,4 +117,3 @@ void export_MoSpaces(py::module& m) {
 }
 }  // namespace py_iface
 }  // namespace adcc
-

--- a/extension/export_OneParticleOperator.cc
+++ b/extension/export_OneParticleOperator.cc
@@ -53,11 +53,12 @@ static py::tuple OneParticleOperator_shape(const OneParticleOperator& self) {
   return shape_tuple(self.shape());
 }
 
-static py::array OneParticleOperator__to_ndarray(const OneParticleOperator& self) {
+static py::array_t<scalar_type> OneParticleOperator__to_ndarray(
+      const OneParticleOperator& self) {
   // Get an empty array of the required shape and export the data into it.
   py::array_t<scalar_type> res(self.shape());
   self.export_to(res.mutable_data(), self.size());
-  return std::move(res);
+  return res;
 }
 
 py::tuple OneParticleOperator__to_ao_basis_ref(const OneParticleOperator& self,

--- a/extension/export_OneParticleOperator.cc
+++ b/extension/export_OneParticleOperator.cc
@@ -53,8 +53,7 @@ static py::tuple OneParticleOperator_shape(const OneParticleOperator& self) {
   return shape_tuple(self.shape());
 }
 
-static py::array_t<scalar_type> OneParticleOperator__to_ndarray(
-      const OneParticleOperator& self) {
+static py::array_t<scalar_type> OneParticleOperator__to_ndarray(const OneParticleOperator& self) {
   // Get an empty array of the required shape and export the data into it.
   py::array_t<scalar_type> res(self.shape());
   self.export_to(res.mutable_data(), self.size());

--- a/extension/export_OneParticleOperator.cc
+++ b/extension/export_OneParticleOperator.cc
@@ -53,7 +53,8 @@ static py::tuple OneParticleOperator_shape(const OneParticleOperator& self) {
   return shape_tuple(self.shape());
 }
 
-static py::array_t<scalar_type> OneParticleOperator__to_ndarray(const OneParticleOperator& self) {
+static py::array_t<scalar_type> OneParticleOperator__to_ndarray(
+      const OneParticleOperator& self) {
   // Get an empty array of the required shape and export the data into it.
   py::array_t<scalar_type> res(self.shape());
   self.export_to(res.mutable_data(), self.size());

--- a/extension/export_OneParticleOperator.cc
+++ b/extension/export_OneParticleOperator.cc
@@ -57,7 +57,7 @@ static py::array OneParticleOperator__to_ndarray(const OneParticleOperator& self
   // Get an empty array of the required shape and export the data into it.
   py::array_t<scalar_type> res(self.shape());
   self.export_to(res.mutable_data(), self.size());
-  return res;
+  return std::move(res);
 }
 
 py::tuple OneParticleOperator__to_ao_basis_ref(const OneParticleOperator& self,

--- a/extension/export_ReferenceState.cc
+++ b/extension/export_ReferenceState.cc
@@ -113,7 +113,7 @@ void export_ReferenceState(py::module& m) {
               [](const ReferenceState& ref) { return ref.nuclear_multipole(0)[0]; })
         .def_property_readonly("nuclear_dipole",
                                [](const ReferenceState& ref) {
-                                 py::array_t<scalar_type> ret({3});
+                                 py::array_t<scalar_type> ret({{3}});
                                  auto res = ref.nuclear_multipole(1);
                                  std::copy(res.begin(), res.end(), ret.mutable_data());
                                  return res;

--- a/extension/export_ReferenceState.cc
+++ b/extension/export_ReferenceState.cc
@@ -113,7 +113,7 @@ void export_ReferenceState(py::module& m) {
               [](const ReferenceState& ref) { return ref.nuclear_multipole(0)[0]; })
         .def_property_readonly("nuclear_dipole",
                                [](const ReferenceState& ref) {
-                                 py::array_t<scalar_type> ret({{3}});
+                                 py::array_t<scalar_type> ret(std::vector<ssize_t>{3});
                                  auto res = ref.nuclear_multipole(1);
                                  std::copy(res.begin(), res.end(), ret.mutable_data());
                                  return res;

--- a/extension/export_Symmetry.cc
+++ b/extension/export_Symmetry.cc
@@ -152,4 +152,3 @@ void export_Symmetry(py::module& m) {
 
 }  // namespace py_iface
 }  // namespace adcc
-

--- a/extension/export_Tensor.cc
+++ b/extension/export_Tensor.cc
@@ -122,7 +122,7 @@ static py::array Tensor_dot_list(const Tensor& self, py::list tensors) {
   py::array_t<scalar_type> ret(dots.size());
   std::copy(dots.begin(), dots.end(), ret.mutable_data());
 
-  return ret;
+  return std::move(ret);
 }
 
 static std::shared_ptr<Tensor> Tensor_transpose_1(const Tensor& self) {

--- a/extension/export_Tensor.cc
+++ b/extension/export_Tensor.cc
@@ -115,14 +115,14 @@ static scalar_type Tensor_dot(const Tensor& self, std::shared_ptr<Tensor> other)
   return self.dot(other);
 }
 
-static py::array Tensor_dot_list(const Tensor& self, py::list tensors) {
+static py::array_t<scalar_type> Tensor_dot_list(const Tensor& self, py::list tensors) {
   std::vector<std::shared_ptr<Tensor>> parsed = extract_tensors(tensors);
   std::vector<scalar_type> dots               = self.dot(parsed);
 
   py::array_t<scalar_type> ret(dots.size());
   std::copy(dots.begin(), dots.end(), ret.mutable_data());
 
-  return std::move(ret);
+  return ret;
 }
 
 static std::shared_ptr<Tensor> Tensor_transpose_1(const Tensor& self) {

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,9 @@ class LinkerDynamic:
 
         for conf in ["/etc/ld.so.conf"] + glob.glob("/etc/ld.so.conf.d/*.conf"):
             if not os.path.isfile(conf):
-                warnings.warn("File {} is broken.".format(conf))
+                warnings.warn("Resolving configuration file {} failed. Probably"
+                              " the file has been remove during distribution upgrade"
+                              " and only a symbolic link to the removed file is left.".format(conf))
                 continue
             with open(conf, "r") as fp:
                 for line in fp:

--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,7 @@ def has_flag(compiler, flagname):
     with tempfile.NamedTemporaryFile("w", suffix=".cpp") as f:
         f.write("int main (int argc, char **argv) { return 0; }")
         try:
-            compiler.compile([f.name], extra_postargs=[flagname])
+            compiler.compile([f.name], extra_postargs=["-Werror", flagname])
         except setuptools.distutils.errors.CompileError:
             return False
     return True

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ import os
 import sys
 import glob
 import setuptools
+import warnings
 
 from os.path import join
 
@@ -87,6 +88,9 @@ class LinkerDynamic:
         self.library_paths += ["/usr/lib", "/lib"]
 
         for conf in ["/etc/ld.so.conf"] + glob.glob("/etc/ld.so.conf.d/*.conf"):
+            if not os.path.isfile(conf):
+                warnings.warn("File {} is broken.".format(conf))
+                continue
             with open(conf, "r") as fp:
                 for line in fp:
                     line = line.strip()

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ except ImportError:
 
 # Version of the python bindings and adcc python package.
 __version__ = "0.13.1"
-adccore_version = ("0.13.2", "")  # (base version, unstable postfix)
+adccore_version = ("0.13.3", "")  # (base version, unstable postfix)
 
 
 def get_adccore_data():


### PR DESCRIPTION
This PR will add support for `clang`, which will be beneficial for `conda` deployment.

## ToDo:
- [x] Apple Clang (10.0.1)
- [x] clang 4.0.1 (conda)
- [x] clang 9.0.0 (conda-forge)
- [x] test clang compilers on Linux (clang 9 from conda-forge)
- [x] test gcc compilers on Linux (gcc 7 from conda-forge)
- [x] revert formatting changes (@mfherbst's clang-format has been run)
- [x] deploy corresponding `adccore` (**done**)
- [x] let Travis run with new `adccore` here (**Change MacOS to use clang**)
- [x] Adapt documentation for MacOS
