### PR TITLE
ADC matrix blockview

### DIFF
--- a/adcc/AdcBlockView.py
+++ b/adcc/AdcBlockView.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+## vi: tabstop=4 shiftwidth=4 softtabstop=4 expandtab
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2020 by the adcc authors
+##
+## This file is part of adcc.
+##
+## adcc is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published
+## by the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## adcc is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with adcc. If not, see <http://www.gnu.org/licenses/>.
+##
+## ---------------------------------------------------------------------
+import numpy as np
+
+from .AdcMatrix import AdcMatrixlike
+from .functions import empty_like
+from .AmplitudeVector import AmplitudeVector
+
+import libadcc
+
+
+class AdcBlockView(AdcMatrixlike):
+    def __init__(self, fullmatrix, block):
+        """
+        Object which acts as a single block of the ADC matrix.
+
+        Parameters
+        ----------
+        fullmatrix : AdcMatrixlike
+            The full matrix of which one wants to view a block
+        block : str
+            The block to view. Valid choices include `s` (view the
+            singles-singles block)or `d` (view the doubles-doubles block).
+        """
+        if block not in fullmatrix.blocks:
+            raise ValueError(f"Block {block} not a valid block of passed "
+                             "matrix {self.__fullmatrix}")
+        self.__block = block
+        self.__fullmatrix = fullmatrix
+        super().__init__(fullmatrix)
+
+    def __repr__(self):
+        return f"AdcBlockView({self.__fullmatrix},{self.__block})"
+
+    @property
+    def blocks(self):
+        return [self.__block]
+
+    def has_block(self, block):
+        return self.__block == block
+
+    def __len__(self):
+        return np.prod([
+            self.mospaces.n_orbs(sp) for sp in self.block_spaces(self.__block)
+        ])
+
+    @property
+    def shape(self):
+        return (len(self), len(self))
+
+    def __assert_block(self, block):
+        if not all(b == self.__block for b in block):
+            raise ValueError(
+                f"The AdcBlockView onto the {self.__block} block of the matrix "
+                "{self.__fullmatrix} does not have block {block}."
+            )
+
+    def diagonal(self, block):
+        self.__assert_block(block)
+        return super().diagonal(block)
+
+    def block_spaces(self, block):
+        self.__assert_block(block)
+        return super().block_spaces(self.__block)
+
+    def compute_matvec(self, in_ampl, out_ampl=None):
+        """
+        Compute the matrix-vector product of the ADC matrix
+        with an excitation amplitude and return the result
+        in the out_ampl if it is given, else the result
+        will be returned.
+        """
+        # Unwrap input object, making sure we have two adcc.Tensors: one
+        # for the input and one for the result
+        return_bare_tensors = True
+        if isinstance(in_ampl, AmplitudeVector):
+            return_bare_tensors = False
+            if not in_ampl.blocks == [self.__block]:
+                raise ValueError("in_ampl does not consist of the correct blocks")
+            in_ampl = in_ampl[self.__block]
+        elif not isinstance(in_ampl, libadcc.Tensor):
+            raise TypeError("in_ampl has to be of type AmplitudeVector "
+                            "or Tensor.")
+        if out_ampl is None:
+            out_ampl = empty_like(in_ampl)
+        elif isinstance(out_ampl, AmplitudeVector):
+            if not out_ampl.blocks == [self.__block]:
+                raise ValueError("out_ampl does not consist of the "
+                                 "correct blocks")
+            out_ampl = out_ampl[self.__block]
+        elif not isinstance(out_ampl, libadcc.Tensor):
+            raise TypeError("out_ampl has to be of type AmplitudeVector "
+                            "or Tensor.")
+
+        # Compute the matrix-vector product
+        super().compute_apply(2 * self.__block, in_ampl, out_ampl)
+
+        if return_bare_tensors:
+            return out_ampl
+        else:
+            # enwrap again in AmplitudeVector
+            if self.__block != "s":
+                raise NotImplementedError
+            return AmplitudeVector(out_ampl)
+
+    def compute_apply(self, block, in_ampl, out_ampl):
+        self.__assert_block(block)
+        super().compute_apply(block, in_ampl, out_ampl)

--- a/adcc/ExcitedStates.py
+++ b/adcc/ExcitedStates.py
@@ -34,9 +34,9 @@ from .OneParticleOperator import product_trace
 from .FormatDominantElements import FormatDominantElements
 
 from adcc import dot
-from scipy import constants
 from matplotlib import pyplot as plt
 
+from scipy import constants
 from .solver.SolverStateBase import EigenSolverStateBase
 
 
@@ -176,10 +176,11 @@ class ExcitedStates:
             if hasattr(data, optattr):
                 setattr(self, optattr, getattr(data, optattr))
 
-        if method is None:
+        self.method = getattr(data, "method", method)
+        if self.method is None:
             self.method = self.matrix.method
-        elif not isinstance(method, AdcMethod):
-            method = AdcMethod(method)
+        if not isinstance(self.method, AdcMethod):
+            self.method = AdcMethod(self.method)
         if property_method is None:
             if self.method.level < 3:
                 property_method = self.method
@@ -187,7 +188,7 @@ class ExcitedStates:
                 # Auto-select ADC(2) properties for ADC(3) calc
                 property_method = self.method.at_level(2)
         elif not isinstance(property_method, AdcMethod):
-            property_method = AdcMethod(method)
+            property_method = AdcMethod(property_method)
         self.__property_method = property_method
 
         # Special stuff for special solvers

--- a/adcc/MoSpaces.py
+++ b/adcc/MoSpaces.py
@@ -22,12 +22,12 @@
 ## ---------------------------------------------------------------------
 import numpy as np
 
+from .backends import import_scf_results
+from .memory_pool import memory_pool
+
 from collections.abc import Iterable
 
 import libadcc
-
-from .backends import import_scf_results
-from .memory_pool import memory_pool
 
 __all__ = ["MoSpaces"]
 
@@ -170,7 +170,7 @@ class MoSpaces(libadcc.MoSpaces):
         The frozen (inactive) virtual spin orbitals
         (in the index convention of the host provider).
         """
-        return self.map_index_hf_provider.get("o2", [])
+        return self.map_index_hf_provider.get("v2", [])
 
 
 # TODO some nice describe method

--- a/adcc/__init__.py
+++ b/adcc/__init__.py
@@ -44,7 +44,7 @@ from libadcc import HartreeFockProvider, get_n_threads, set_n_threads
 # This has to be the last set of import
 from .guess import (guess_symmetries, guess_zero, guesses_any, guesses_singlet,
                     guesses_spin_flip, guesses_triplet)
-from .run_adc import run_adc
+from .workflow import run_adc
 
 __all__ = ["run_adc", "AdcMatrix", "AdcBlockView", "AdcMatrixlike", "AdcMethod",
            "Symmetry", "ReferenceState",

--- a/adcc/__init__.py
+++ b/adcc/__init__.py
@@ -25,12 +25,13 @@ import sys
 from .LazyMp import LazyMp
 from .Tensor import Tensor
 from .Symmetry import Symmetry
-from .AdcMatrix import AdcMatrix
+from .AdcMatrix import AdcMatrix, AdcMatrixlike
 from .AdcMethod import AdcMethod
 from .functions import (add, contract, copy, divide, dot, empty_like,
                         linear_combination, multiply, nosym_like, ones_like,
                         subtract, transpose, zeros_like)
 from .memory_pool import memory_pool
+from .AdcBlockView import AdcBlockView
 from .ExcitedStates import ExcitedStates
 from .DataHfProvider import DataHfProvider, DictHfProvider
 from .ReferenceState import ReferenceState
@@ -45,7 +46,8 @@ from .guess import (guess_symmetries, guess_zero, guesses_any, guesses_singlet,
                     guesses_spin_flip, guesses_triplet)
 from .run_adc import run_adc
 
-__all__ = ["run_adc", "AdcMatrix", "AdcMethod", "Symmetry", "ReferenceState",
+__all__ = ["run_adc", "AdcMatrix", "AdcBlockView", "AdcMatrixlike", "AdcMethod",
+           "Symmetry", "ReferenceState",
            "add", "contract", "copy", "divide", "dot", "empty_like",
            "linear_combination", "multiply", "nosym_like", "ones_like",
            "subtract", "transpose", "zeros_like",

--- a/adcc/solver/davidson.py
+++ b/adcc/solver/davidson.py
@@ -24,7 +24,8 @@ import sys
 import warnings
 import numpy as np
 
-from adcc import AdcMatrix, linear_combination
+from adcc import linear_combination
+from adcc.AdcMatrix import AdcMatrixlike
 from adcc.AmplitudeVector import AmplitudeVector
 
 import scipy.linalg as la
@@ -350,8 +351,8 @@ def eigsh(matrix, guesses, n_ep=None, max_subspace=None,
         a new subspace vector
         (defaults to 2 * len(matrix) * machine_expsilon)
     """
-    if not isinstance(matrix, AdcMatrix):
-        raise TypeError("matrix is not of type AdcMatrix")
+    if not isinstance(matrix, AdcMatrixlike):
+        raise TypeError("matrix is not of type AdcMatrixlike")
     for guess in guesses:
         if not isinstance(guess, AmplitudeVector):
             raise TypeError("One of the guesses is not of type AmplitudeVector")

--- a/adcc/solver/preconditioner.py
+++ b/adcc/solver/preconditioner.py
@@ -22,7 +22,7 @@
 ## ---------------------------------------------------------------------
 import numpy as np
 
-from adcc.AdcMatrix import AdcMatrix
+from adcc.AdcMatrix import AdcMatrixlike
 from adcc.functions import divide, empty_like, ones_like
 from adcc.AmplitudeVector import AmplitudeVector
 
@@ -51,8 +51,8 @@ class JacobiPreconditioner:
     D is the diagonal of the adcmatrix.
     """
     def __init__(self, adcmatrix, shifts=0.0):
-        if not isinstance(adcmatrix, AdcMatrix):
-            raise TypeError("Only an AdcMatrix may be used with this "
+        if not isinstance(adcmatrix, AdcMatrixlike):
+            raise TypeError("Only an AdcMatrixlike may be used with this "
                             "preconditioner for now.")
 
         self.diagonal = AmplitudeVector(*tuple(

--- a/adcc/test_AdcBlockView.py
+++ b/adcc/test_AdcBlockView.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+## vi: tabstop=4 shiftwidth=4 softtabstop=4 expandtab
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2020 by the adcc authors
+##
+## This file is part of adcc.
+##
+## adcc is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published
+## by the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## adcc is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with adcc. If not, see <http://www.gnu.org/licenses/>.
+##
+## ---------------------------------------------------------------------
+import adcc
+import unittest
+
+from .misc import expand_test_templates
+from adcc.testdata.cache import cache
+
+methods = ["adc1", "adc2", "adc2x", "adc3", "cvs-adc1", "cvs-adc2x"]
+
+
+@expand_test_templates(methods)
+class TestAdcMatrixBlockView(unittest.TestCase):
+    def template_singles_view(self, method):
+        if "cvs" in method:
+            reference_state = cache.refstate_cvs["h2o_sto3g"]
+            shape = (8, 8)
+            spaces_s = ["o2", "v1"]
+        else:
+            reference_state = cache.refstate["h2o_sto3g"]
+            shape = (40, 40)
+            spaces_s = ["o1", "v1"]
+        matrix = adcc.AdcMatrix(method, adcc.LazyMp(reference_state))
+        view = adcc.AdcBlockView(matrix, "s")
+
+        assert view.ndim == 2
+        assert view.is_core_valence_separated == ("cvs" in method)
+        assert view.shape == shape
+        assert len(view) == shape[0]
+
+        assert view.blocks == ["s"]
+        assert view.has_block("s")
+        assert not view.has_block("d")
+        assert not view.has_block("t")
+        assert view.block_spaces("s") == spaces_s
+
+        assert view.reference_state == reference_state
+        assert view.mospaces == reference_state.mospaces
+        assert isinstance(view.timer, adcc.timings.Timer)
+        assert view.to_cpp() == matrix.to_cpp()
+
+        # Check diagonal
+        diff = matrix.diagonal("s") - view.diagonal("s")
+        assert diff.dot(diff) < 1e-12
+
+        # Check @ (one vector and multiple vectors)
+        invec = adcc.guess_zero(matrix)
+        invec["s"].set_random()
+        # "d" left as zero
+        invec_singles = adcc.AmplitudeVector(invec["s"])
+
+        ref = matrix @ invec
+        res = view @ invec_singles
+        diff = res["s"] - ref["s"]
+        assert diff.dot(diff) < 1e-12
+
+        res = view @ [invec_singles, invec_singles, invec_singles]
+        diff = [res[i]["s"] - ref["s"] for i in range(3)]
+        assert max(d.dot(d) for d in diff) < 1e-12
+
+        # Missing: Check for compute_matvec and compute_apply

--- a/adcc/test_AdcMatrix.py
+++ b/adcc/test_AdcMatrix.py
@@ -28,6 +28,8 @@ from .misc import expand_test_templates
 from numpy.testing import assert_allclose
 from adcc.testdata.cache import cache
 
+import libadcc
+
 methods = ["adc1", "adc2", "adc2x", "adc3"]
 methods += ["cvs-" + m for m in methods]
 
@@ -72,3 +74,112 @@ class TestAdcMatrixDenseExport(unittest.TestCase):
     #         and allows e.g. simultaneous α->α and α->β components to mix
     #         A closer investigation is needed here
     #    self.base_test("cn_sto3g", method, **kwargs)
+
+
+class TestAdcMatrixInterface(unittest.TestCase):
+    def test_properties_adc2(self):
+        case = "h2o_sto3g"
+        method = "adc2"
+
+        reference_state = cache.refstate[case]
+        ground_state = adcc.LazyMp(reference_state)
+        matrix = adcc.AdcMatrix(method, ground_state)
+
+        assert matrix.ndim == 2
+        assert not matrix.is_core_valence_separated
+        assert matrix.shape == (1640, 1640)
+        assert len(matrix) == 1640
+
+        assert matrix.blocks == ["s", "d"]
+        assert matrix.has_block("s")
+        assert matrix.has_block("d")
+        assert not matrix.has_block("t")
+        assert matrix.block_spaces("s") == ["o1", "v1"]
+        assert matrix.block_spaces("d") == ["o1", "o1", "v1", "v1"]
+
+        assert matrix.reference_state == reference_state
+        assert matrix.mospaces == reference_state.mospaces
+        assert isinstance(matrix.timer, adcc.timings.Timer)
+        assert isinstance(matrix.to_cpp(), libadcc.AdcMatrix)
+
+    def test_properties_cvs_adc1(self):
+        case = "h2o_sto3g"
+        method = "cvs-adc1"
+
+        reference_state = cache.refstate_cvs[case]
+        ground_state = adcc.LazyMp(reference_state)
+        matrix = adcc.AdcMatrix(method, ground_state)
+
+        assert matrix.ndim == 2
+        assert matrix.is_core_valence_separated
+        assert matrix.shape == (8, 8)
+        assert len(matrix) == 8
+
+        assert matrix.blocks == ["s"]
+        assert matrix.has_block("s")
+        assert not matrix.has_block("d")
+        assert not matrix.has_block("t")
+        assert matrix.block_spaces("s") == ["o2", "v1"]
+
+        assert matrix.reference_state == reference_state
+        assert matrix.mospaces == reference_state.mospaces
+        assert isinstance(matrix.timer, adcc.timings.Timer)
+        assert isinstance(matrix.to_cpp(), libadcc.AdcMatrix)
+
+    def test_intermediates_adc2(self):
+        ground_state = adcc.LazyMp(cache.refstate["h2o_sto3g"])
+        matrix = adcc.AdcMatrix("adc2", ground_state)
+        assert isinstance(matrix.intermediates, libadcc.AdcIntermediates)
+        intermediates = libadcc.AdcIntermediates(ground_state)
+        matrix.intermediates = intermediates
+        assert matrix.intermediates == intermediates
+
+    def test_diagonal_adc2(self):
+        ground_state = adcc.LazyMp(cache.refstate["h2o_sto3g"])
+        matrix = adcc.AdcMatrix("adc2", ground_state)
+        cppmatrix = libadcc.AdcMatrix("adc2", ground_state)
+        diff = cppmatrix.diagonal("s") - matrix.diagonal("s")
+        assert diff.dot(diff) < 1e-12
+
+    def test_matvec_adc2(self):
+        ground_state = adcc.LazyMp(cache.refstate["h2o_sto3g"])
+        matrix = adcc.AdcMatrix("adc2", ground_state)
+        cppmatrix = libadcc.AdcMatrix("adc2", ground_state)
+
+        vectors = [adcc.guess_zero(matrix) for i in range(3)]
+        for vec in vectors:
+            vec["s"].set_random()
+            vec["d"].set_random()
+        v, w, x = vectors
+
+        # Compute references:
+        refv = adcc.empty_like(v)
+        refw = adcc.empty_like(w)
+        refx = adcc.empty_like(x)
+        cppmatrix.compute_matvec(v.to_cpp(), refv.to_cpp())
+        cppmatrix.compute_matvec(w.to_cpp(), refw.to_cpp())
+        cppmatrix.compute_matvec(x.to_cpp(), refx.to_cpp())
+
+        # @ operator (1 vector)
+        resv = matrix @ v
+        diffv = refv - resv
+        assert diffv["s"].dot(diffv["s"]) < 1e-12
+        assert diffv["d"].dot(diffv["d"]) < 1e-12
+
+        # @ operator (multiple vectors)
+        resv, resw, resx = matrix @ [v, w, x]
+        diffs = [refv - resv, refw - resw, refx - resx]
+        for i in range(3):
+            assert diffs[i]["s"].dot(diffs[i]["s"]) < 1e-12
+            assert diffs[i]["d"].dot(diffs[i]["d"]) < 1e-12
+
+        # compute matvec
+        matrix.compute_matvec(v, resv)
+        diffv = refv - resv
+        assert diffv["s"].dot(diffv["s"]) < 1e-12
+        assert diffv["d"].dot(diffv["d"]) < 1e-12
+
+        matrix.compute_apply("ss", v["s"], resv["s"])
+        cppmatrix.compute_apply("ss", v["s"], refv["s"])
+        diffv = resv["s"] - refv["s"]
+        assert diffv.dot(diffv) < 1e-12

--- a/adcc/test_workflow.py
+++ b/adcc/test_workflow.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+## vi: tabstop=4 shiftwidth=4 softtabstop=4 expandtab
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2020 by the adcc authors
+##
+## This file is part of adcc.
+##
+## adcc is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published
+## by the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## adcc is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with adcc. If not, see <http://www.gnu.org/licenses/>.
+##
+## ---------------------------------------------------------------------
+import adcc
+
+from adcc.testdata.cache import cache
+
+import pytest
+
+from pytest import approx
+
+
+class TestWorkflow:
+    def test_validate_state_parameters_rhf(self):
+        from adcc.workflow import validate_state_parameters
+
+        refstate = cache.refstate["h2o_sto3g"]
+
+        assert 3, "any" == validate_state_parameters(refstate, n_states=3)
+        assert 4, "singlet" == validate_state_parameters(refstate, n_states=4,
+                                                         kind="singlet")
+        assert 2, "triplet" == validate_state_parameters(refstate, n_states=2,
+                                                         kind="triplet")
+        assert 2, "triplet" == validate_state_parameters(refstate, n_triplets=2)
+        assert 6, "singlet" == validate_state_parameters(refstate, n_singlets=6)
+
+        invalid_cases = [
+            dict(),                # No states requested
+            dict(n_states=0),      # No states requested
+            dict(n_singlets=-2),   # Negative number of states requested
+            dict(n_spin_flip=2),   # Invalid kind of states for RHF
+            dict(n_states=2, n_singlets=2),      # States of two sorts
+            dict(n_triplets=2, n_singlets=2),    # States of two sorts
+            dict(n_states=2, n_spin_flip=2),     # States of two sorts
+            dict(n_triplets=2, kind="singlet"),  # kind and n_ do not agree
+            dict(n_states=2, kind="bla"),      # Kind invaled
+        ]
+        for case in invalid_cases:
+            with pytest.raises(ValueError):
+                validate_state_parameters(refstate, **case)
+
+    def test_validate_state_parameters_uhf(self):
+        from adcc.workflow import validate_state_parameters
+
+        refstate = cache.refstate["cn_sto3g"]
+
+        assert 3, "any" == validate_state_parameters(refstate, n_states=3,
+                                                     kind="any")
+        assert 3, "any" == validate_state_parameters(refstate, n_states=3)
+        assert 2, "spin_flip" == validate_state_parameters(refstate,
+                                                           n_spin_flip=2)
+
+        invalid_cases = [
+            dict(),                # No states requested
+            dict(n_states=0),      # No states requested
+            dict(n_states=-2),     # Negative number of states requested
+            dict(n_spin_flip=-3),  # Negative number of states requested
+            dict(n_states=2, n_singlets=2),    # States of two sorts
+            dict(n_triplets=2, n_singlets=2),  # States of two sorts
+            dict(n_states=2, n_spin_flip=2),   # States of two sorts
+            dict(n_spin_flip=2, kind="singlet"),  # kind and n_ do not agree
+            dict(n_states=2, kind="bla"),      # Kind invaled
+            dict(n_states=4, kind="singlet"),  # UHF with singlets
+            dict(n_states=2, kind="triplet"),  # UHF with triplets
+            dict(n_triplets=2),    # UHF with triplets
+            dict(n_singlets=6),    # UHF with singlets
+        ]
+        for case in invalid_cases:
+            with pytest.raises(ValueError):
+                validate_state_parameters(refstate, **case)
+
+    def test_construct_adcmatrix(self):
+        from adcc.workflow import construct_adcmatrix
+
+        #
+        # Construction from hfdata
+        #
+        hfdata = cache.hfdata["h2o_sto3g"]
+
+        res = construct_adcmatrix(hfdata, method="adc3")
+        assert isinstance(res, adcc.AdcMatrix)
+        assert res.method == adcc.AdcMethod("adc3")
+        assert res.mospaces.core_orbitals == []
+        assert res.mospaces.frozen_core == []
+        assert res.mospaces.frozen_virtual == []
+
+        res = construct_adcmatrix(hfdata, method="cvs-adc3", core_orbitals=1)
+        assert isinstance(res, adcc.AdcMatrix)
+        assert res.method == adcc.AdcMethod("cvs-adc3")
+        assert res.mospaces.core_orbitals == [0, 7]
+        assert res.mospaces.frozen_core == []
+        assert res.mospaces.frozen_virtual == []
+
+        res = construct_adcmatrix(hfdata, method="adc2", frozen_core=1)
+        assert res.mospaces.core_orbitals == []
+        assert res.mospaces.frozen_core == [0, 7]
+        assert res.mospaces.frozen_virtual == []
+
+        res = construct_adcmatrix(hfdata, method="adc2", frozen_virtual=1)
+        assert res.mospaces.core_orbitals == []
+        assert res.mospaces.frozen_core == []
+        assert res.mospaces.frozen_virtual == [6, 13]
+
+        res = construct_adcmatrix(hfdata, method="adc2", frozen_virtual=1,
+                                  frozen_core=1)
+        assert res.mospaces.core_orbitals == []
+        assert res.mospaces.frozen_core == [0, 7]
+        assert res.mospaces.frozen_virtual == [6, 13]
+
+        invalid_cases = [
+            dict(),                   # Missing method
+            dict(frozen_core=1),      # Missing method
+            dict(frozen_virtual=3),   # Missing method
+            dict(core_orbitals=4),    # Missing method
+            dict(method="cvs-adc2"),  # No core_orbitals
+            dict(method="cvs-adc2", frozen_core=1),
+            dict(method="adc2", core_orbitals=3),  # Extra core parameter
+            dict(method="adc2", core_orbitals=3, frozen_virtual=2),
+        ]
+        for case in invalid_cases:
+            with pytest.raises(ValueError):
+                construct_adcmatrix(hfdata, **case)
+
+        #
+        # Construction from LazyMp or ReferenceState
+        #
+        refst_ful = cache.refstate["h2o_sto3g"]
+        refst_cvs = cache.refstate_cvs["h2o_sto3g"]
+        gs_ful, gs_cvs = adcc.LazyMp(refst_ful), adcc.LazyMp(refst_cvs)
+
+        for obj in [gs_ful, refst_ful]:
+            res = construct_adcmatrix(obj, method="adc2")
+            assert isinstance(res, adcc.AdcMatrix)
+            assert res.method == adcc.AdcMethod("adc2")
+
+            with pytest.raises(ValueError,
+                               match=r"Cannot run a core-valence"):
+                construct_adcmatrix(obj, method="cvs-adc2x")
+            with pytest.warns(UserWarning,
+                              match=r"^Ignored frozen_core parameter"):
+                construct_adcmatrix(obj, frozen_core=3, method="adc1")
+            with pytest.warns(UserWarning,
+                              match=r"^Ignored frozen_virtual parameter"):
+                construct_adcmatrix(obj, frozen_virtual=1, method="adc3")
+
+        for obj in [gs_cvs, refst_cvs]:
+            res = construct_adcmatrix(obj, method="cvs-adc2x")
+            assert isinstance(res, adcc.AdcMatrix)
+            assert res.method == adcc.AdcMethod("cvs-adc2x")
+
+            with pytest.raises(ValueError):
+                construct_adcmatrix(obj)  # Missing method
+            with pytest.raises(ValueError, match=r"Cannot run a general"):
+                construct_adcmatrix(obj, method="adc2")
+            with pytest.warns(UserWarning,
+                              match=r"^Ignored core_orbitals parameter"):
+                construct_adcmatrix(obj, core_orbitals=2, method="cvs-adc1")
+
+        #
+        # Construction from ADC matrix
+        #
+        mtx_ful = adcc.AdcMatrix("adc2", gs_ful)
+        mtx_cvs = adcc.AdcMatrix("cvs-adc2", gs_cvs)
+        assert construct_adcmatrix(mtx_ful) == mtx_ful
+        assert construct_adcmatrix(mtx_ful, method="adc2") == mtx_ful
+        assert construct_adcmatrix(mtx_cvs) == mtx_cvs
+        assert construct_adcmatrix(mtx_cvs, method="cvs-adc2") == mtx_cvs
+
+        with pytest.warns(UserWarning, match=r"Ignored method parameter"):
+            construct_adcmatrix(mtx_ful, method="adc3")
+        with pytest.warns(UserWarning, match=r"^Ignored core_orbitals parameter"):
+            construct_adcmatrix(mtx_cvs, core_orbitals=2)
+        with pytest.warns(UserWarning, match=r"^Ignored frozen_core parameter"):
+            construct_adcmatrix(mtx_ful, frozen_core=3)
+        with pytest.warns(UserWarning,
+                          match=r"^Ignored frozen_virtual parameter"):
+            construct_adcmatrix(mtx_cvs, frozen_virtual=1)
+
+    def test_diagonalise_adcmatrix(self):
+        from adcc.workflow import diagonalise_adcmatrix
+
+        refdata = cache.reference_data["h2o_sto3g"]
+        matrix = adcc.AdcMatrix("adc2", adcc.LazyMp(cache.refstate["h2o_sto3g"]))
+
+        res = diagonalise_adcmatrix(matrix, n_states=3, kind="singlet",
+                                    solver_method="davidson")
+        ref_singlets = refdata["adc2"]["singlet"]["eigenvalues"]
+        assert res.converged
+        assert res.eigenvalues == approx(ref_singlets[:3])
+
+        guesses = adcc.guesses_singlet(matrix, n_guesses=6, block="s")
+        res = diagonalise_adcmatrix(matrix, n_states=3, kind="singlet",
+                                    guesses=guesses)
+        ref_singlets = refdata["adc2"]["singlet"]["eigenvalues"]
+        assert res.converged
+        assert res.eigenvalues == approx(ref_singlets[:3])
+
+        with pytest.raises(ValueError):  # Too low tolerance
+            res = diagonalise_adcmatrix(matrix, n_states=9, kind="singlet",
+                                        solver_method="davidson",
+                                        conv_tol=1e-14)
+
+        with pytest.raises(ValueError):  # Wrong solver method
+            res = diagonalise_adcmatrix(matrix, n_states=9, kind="singlet",
+                                        solver_method="blubber")
+
+        with pytest.raises(ValueError):  # Too few guesses
+            res = diagonalise_adcmatrix(matrix, n_states=9, kind="singlet",
+                                        solver_method="davidson",
+                                        guesses=guesses)
+
+    def test_estimate_n_guesses(self):
+        from adcc.workflow import estimate_n_guesses
+
+        refstate = cache.refstate["h2o_sto3g"]
+        ground_state = adcc.LazyMp(refstate)
+        matrix = adcc.AdcMatrix("adc2", ground_state)
+
+        # Check minimal number of guesses is 4 and at some point
+        # we get more than four guesses
+        assert 4 == estimate_n_guesses(matrix, n_states=1, singles_only=True)
+        assert 4 == estimate_n_guesses(matrix, n_states=2, singles_only=True)
+        for i in range(3, 20):
+            assert i <= estimate_n_guesses(matrix, n_states=i, singles_only=True)
+
+    def test_obtain_guesses_by_inspection(self):
+        from adcc.workflow import obtain_guesses_by_inspection
+
+        refstate = cache.refstate["h2o_sto3g"]
+        ground_state = adcc.LazyMp(refstate)
+        matrix2 = adcc.AdcMatrix("adc2", ground_state)
+        matrix1 = adcc.AdcMatrix("adc1", ground_state)
+
+        # Test that the right number of guesses is returned ...
+        for mat in [matrix1, matrix2]:
+            for i in range(4, 9):
+                res = obtain_guesses_by_inspection(mat, n_guesses=i,
+                                                   kind="singlet")
+                assert len(res) == i
+
+        for i in range(4, 9):
+            res = obtain_guesses_by_inspection(
+                matrix2, n_guesses=i, kind="triplet", n_guesses_doubles=2)
+            assert len(res) == i
+
+        with pytest.raises(ValueError):
+            obtain_guesses_by_inspection(matrix1, n_guesses=4, kind="any",
+                                         n_guesses_doubles=2)
+        with pytest.raises(ValueError):
+            obtain_guesses_by_inspection(matrix1, n_guesses=40, kind="any")

--- a/adcc/workflow.py
+++ b/adcc/workflow.py
@@ -26,10 +26,11 @@ import warnings
 from . import solver
 from .guess import (guesses_any, guesses_singlet, guesses_spin_flip,
                     guesses_triplet)
-from .AdcMatrix import AdcMatrix
+from .AdcMatrix import AdcMatrix, AdcMatrixlike
 from .AdcMethod import AdcMethod
 from .ExcitedStates import ExcitedStates
 from .ReferenceState import ReferenceState as adcc_ReferenceState
+
 from .solver.davidson import jacobi_davidson
 from .solver.explicit_symmetrisation import (IndexSpinSymmetrisation,
                                              IndexSymmetrisation)
@@ -44,7 +45,6 @@ def run_adc(data_or_matrix, n_states=None, kind="any", conv_tol=None,
             n_guesses_doubles=None, output=sys.stdout, core_orbitals=None,
             frozen_core=None, frozen_virtual=None, method=None,
             n_singlets=None, n_triplets=None, n_spin_flip=None,
-            n_core_orbitals=None,
             **solverargs):
     """Run an ADC calculation.
 
@@ -170,25 +170,57 @@ def run_adc(data_or_matrix, n_states=None, kind="any", conv_tol=None,
     ...
     ... state = adcc.cvs_adc3(mf, core_orbitals=1, n_singlets=3)
     """
-    #
-    # Input argument sanitisation
-    #
-    if solver_method is None:
-        solver_method = "jacobi_davidson"
+    matrix = construct_adcmatrix(
+        data_or_matrix, core_orbitals=core_orbitals, frozen_core=frozen_core,
+        frozen_virtual=frozen_virtual, method=method)
 
-    # Step 1: Construct at least ReferenceState
-    if not isinstance(data_or_matrix, AdcMatrix) and method is None:
+    n_states, kind = normalise_state_parameters(
+        matrix.reference_state, n_states=n_states, n_singlets=n_singlets,
+        n_triplets=n_triplets, n_spin_flip=n_spin_flip, kind=kind)
+
+    # Determine spin change during excitation. If guesses is not None,
+    # i.e. user-provided, we cannot guarantee for obtaining a particular
+    # spin_change in case of a spin_flip calculation.
+    spin_change = None
+    if kind == "spin_flip" and guesses is None:
+        spin_change = -1
+
+    # Select solver to run
+    if solver_method is None:
+        solver_method = "davidson"
+
+    if solver_method in ["davidson"]:
+        diagres = diagonalise_adcmatrix(
+            matrix, n_states, kind, guesses=guesses, n_guesses=n_guesses,
+            n_guesses_doubles=n_guesses_doubles, conv_tol=conv_tol, output=output,
+            solver_method=solver_method, **solverargs)
+        exstates = ExcitedStates(diagres)
+        exstates.kind = kind
+        exstates.spin_change = spin_change
+        return exstates
+    else:
+        raise NotImplementedError(f"Solver method {solver_method} not "
+                                  "implemented. Try 'davidson' or 'auto'")
+
+
+#
+# Individual steps
+#
+def construct_adcmatrix(data_or_matrix, core_orbitals=None, frozen_core=None,
+                        frozen_virtual=None, method=None):
+    """
+    Use the provided data or AdcMatrix object to check consistency of the
+    other passed parameters and construct the AdcMatrix object representing
+    the problem to be solved.
+    Internal function called from run_adc.
+    """
+    if not isinstance(data_or_matrix, AdcMatrixlike) and method is None:
         raise ValueError("method needs to be explicitly provided unless "
-                         "data_or_matrix is an AdcMatrix.")
+                         "data_or_matrix is an AdcMatrixlike.")
     if method is not None and not isinstance(method, AdcMethod):
         method = AdcMethod(method)
 
-    if n_core_orbitals is not None:
-        warnings.warn(DeprecationWarning("n_core_orbitals is a deprecated "
-                                         "option. Use core_orbitals instead."))
-        core_orbitals = n_core_orbitals
-
-    if not isinstance(data_or_matrix, (ReferenceState, AdcMatrix, LazyMp)):
+    if not isinstance(data_or_matrix, (ReferenceState, AdcMatrixlike, LazyMp)):
         if method.is_core_valence_separated and core_orbitals is None:
             raise ValueError("If core-valence separation approximation is "
                              "applied then the number of core orbitals needs "
@@ -202,66 +234,59 @@ def run_adc(data_or_matrix, n_states=None, kind="any", conv_tol=None,
     elif core_orbitals is not None:
         mospaces = data_or_matrix.mospaces
         warnings.warn("Ignored core_orbitals parameter because data_or_matrix"
-                      " is a ReferenceState, a LazyMp or an AdcMatrix object "
+                      " is a ReferenceState, a LazyMp or an AdcMatrixlike object "
                       " (which has a value of core_orbitals={})."
                       "".format(mospaces.n_orbs_alpha("o2")))
     elif frozen_core is not None:
         mospaces = data_or_matrix.mospaces
         warnings.warn("Ignored frozen_core parameter because data_or_matrix"
-                      " is a ReferenceState, a LazyMp or an AdcMatrix object "
+                      " is a ReferenceState, a LazyMp or an AdcMatrixlike object "
                       " (which has a value of frozen_core={})."
                       "".format(mospaces.n_orbs_alpha("o3")))
     elif frozen_virtual is not None:
         mospaces = data_or_matrix.mospaces
         warnings.warn("Ignored frozen_virtual parameter because data_or_matrix"
-                      " is a ReferenceState, a LazyMp or an AdcMatrix object "
+                      " is a ReferenceState, a LazyMp or an AdcMatrixlike object "
                       " (which has a value of frozen_virtual={})."
                       "".format(mospaces.n_orbs_alpha("v2")))
 
-    # Step2: Make AdcMatrix
+    # Make AdcMatrix (if not done)
     if isinstance(data_or_matrix, (ReferenceState, LazyMp)):
-        matrix = AdcMatrix(method, data_or_matrix)
+        return AdcMatrix(method, data_or_matrix)
     elif method is not None and method != data_or_matrix.method:
-        print(method, data_or_matrix.method)
         warnings.warn("Ignored method parameter because data_or_matrix is an"
-                      " AdcMatrix, which implicitly already defines the method")
-    if isinstance(data_or_matrix, AdcMatrix):
-        matrix = data_or_matrix
-    refstate = matrix.reference_state
+                      " AdcMatrixlike, which implicitly sets the method")
+    if isinstance(data_or_matrix, AdcMatrixlike):
+        return data_or_matrix
 
-    if solver_method != "jacobi_davidson":
-        raise NotImplementedError("Only the jacobi_davidson solver_method "
-                                  "is implemented.")
 
-    # Determine default ADC convergence tolerance
-    if conv_tol is None:
-        conv_tol = max(refstate.conv_tol / 100, 1e-6)
-    if refstate.conv_tol > conv_tol:
-        raise ValueError("Convergence tolerance of SCF results (== {}) needs to"
-                         " be lower than ADC convergence tolerance parameter "
-                         "conv_tol (== {}).".format(refstate.conv_tol,
-                                                    conv_tol))
-
-    # Normalise guess parameters
+def normalise_state_parameters(reference_state, n_states=None, n_singlets=None,
+                               n_triplets=None, n_spin_flip=None, kind="any"):
+    """
+    Check the passed state parameters for consistency with itself and with
+    the passed reference and normalise them. In the end return the number of
+    states and the corresponding kind parameter selected.
+    Internal function called from run_adc.
+    """
     if sum(nst is not None for nst in [n_states, n_singlets,
                                        n_triplets, n_spin_flip]) > 1:
         raise ValueError("One May only specify one out of n_states, "
                          "n_singlets, n_triplets and n_spin_flip")
 
     if n_singlets is not None:
-        if not refstate.restricted:
+        if not reference_state.restricted:
             raise ValueError("The n_singlets parameter may only be employed "
                              "for restricted references")
         kind = "singlet"
         n_states = n_singlets
     if n_triplets is not None:
-        if not refstate.restricted:
+        if not reference_state.restricted:
             raise ValueError("The n_triplets parameter may only be employed "
                              "for restricted references")
         kind = "triplet"
         n_states = n_triplets
     if n_spin_flip is not None:
-        if refstate.restricted:
+        if reference_state.restricted:
             raise ValueError("The n_spin_flip parameter may only be employed "
                              "for unrestricted references")
         kind = "spin_flip"
@@ -277,71 +302,71 @@ def run_adc(data_or_matrix, n_states=None, kind="any", conv_tol=None,
     if kind not in ["any", "spin_flip", "singlet", "triplet"]:
         raise ValueError("The kind parameter may only take the values 'any', "
                          "'singlet', 'triplet' or 'spin_flip'")
-    if kind in ["singlet", "triplet"] and not refstate.restricted:
+    if kind in ["singlet", "triplet"] and not reference_state.restricted:
         raise ValueError("kind==singlet and kind==triplet are only valid for "
                          "ADC calculations in combination with a restricted "
                          "ground state.")
-    if kind in ["spin_flip"] and refstate.restricted:
+    if kind in ["spin_flip"] and reference_state.restricted:
         raise ValueError("kind==spin_flip is only valid for "
                          "ADC calculations in combination with an unrestricted "
                          "ground state.")
+    return n_states, kind
 
+
+def diagonalise_adcmatrix(matrix, n_states, kind, solver_method="davidson",
+                          guesses=None, n_guesses=None, n_guesses_doubles=None,
+                          conv_tol=None, output=sys.stdout, **solverargs):
+    """
+    This function seeks appropriate guesses and afterwards proceeds to
+    diagonalise the ADC matrix using the specified solver_method.
+    Internal function called from run_adc.
+    """
+    reference_state = matrix.reference_state
+
+    # Determine default ADC convergence tolerance
+    if conv_tol is None:
+        conv_tol = max(reference_state.conv_tol / 100, 1e-6)
+    if reference_state.conv_tol > conv_tol:
+        raise ValueError(
+            f"Convergence tolerance of SCF results "
+            "(== {reference_state.conv_tol}) needs to be lower than ADC "
+            "convergence tolerance parameter conv_tol (== {conv_tol})."
+        )
+
+    # Determine explicit_symmetrisation
     explicit_symmetrisation = IndexSymmetrisation
     if kind in ["singlet", "triplet"]:
         explicit_symmetrisation = IndexSpinSymmetrisation(
             matrix, enforce_spin_kind=kind
         )
 
-    # Guess parameters
-    if n_guesses_doubles is not None and n_guesses_doubles > 0 \
-       and "d" not in matrix.blocks:
-        raise ValueError("n_guesses_doubles > 0 is only sensible if the ADC "
-                         "method has a doubles block (i.e. it is *not* ADC(0), "
-                         "ADC(1) or a variant thereof.")
-
-    #
-    # Obtain guesses
-    #
-    spin_change = None
-    if guesses is not None:
+    # Obtain or check guesses
+    if guesses is None:
+        if n_guesses is None:
+            n_guesses = estimate_n_guesses(matrix, n_states)
+        guesses = obtain_guesses_by_inspection(matrix, n_states, kind,
+                                               n_guesses, n_guesses_doubles)
+    else:
         if len(guesses) < n_states:
             raise ValueError("Less guesses provided via guesses (== {}) "
                              "than states to be computed (== {})"
                              "".format(len(guesses), n_states))
         if n_guesses is not None:
             warnings.warn("Ignoring n_guesses parameter, since guesses are "
-                          "explicitly provided")
+                          "explicitly provided.")
+        if n_guesses_doubles is not None:
+            warnings.warn("Ignoring n_guesses_doubles parameter, since guesses "
+                          "are explicitly provided.")
+
+    if solver_method == "davidson":
+        callback = setup_solver_printing(
+            "Jacobi-Davidson", matrix, kind, solver.davidson.default_print,
+            output=output)
+        return jacobi_davidson(matrix, guesses, n_ep=n_states, conv_tol=conv_tol,
+                               explicit_symmetrisation=explicit_symmetrisation,
+                               callback=callback, **solverargs)
     else:
-        if n_guesses is None:
-            n_guesses = estimate_n_guesses(matrix, n_states)
-        if kind == "spin_flip":
-            spin_change = -1
-
-        guess_function = {"any": guesses_any, "singlet": guesses_singlet,
-                          "triplet": guesses_triplet,
-                          "spin_flip": guesses_spin_flip}
-        guesses = find_guesses(guess_function[kind], matrix, n_guesses,
-                               n_guesses_doubles=n_guesses_doubles)
-
-    #
-    # Run solver
-    #
-    jd_callback = None
-    if output:
-        def jd_callback(state, identifier):
-            solver.davidson.default_print(state, identifier, output)
-        kstr = " " if kind == "any" else " " + kind + " "
-        print("Starting " + matrix.method.name + " " + kstr
-              + "Jacobi-Davidson ...", file=output)
-
-    jdres = jacobi_davidson(matrix, guesses, n_ep=n_states,
-                            conv_tol=conv_tol, callback=jd_callback,
-                            explicit_symmetrisation=explicit_symmetrisation,
-                            **solverargs)
-    exstates = ExcitedStates(jdres)
-    exstates.kind = kind
-    exstates.spin_change = spin_change
-    return exstates
+        raise NotImplementedError(f"Solver {solver_method} not implemented.")
 
 
 def estimate_n_guesses(matrix, n_states, singles_only=True):
@@ -377,13 +402,13 @@ def estimate_n_guesses(matrix, n_states, singles_only=True):
     return max(n_states, n_guesses)
 
 
-def find_guesses(guessfctn, matrix, n_guesses, n_guesses_doubles=None):
+def obtain_guesses_by_inspection(matrix, n_states, kind, n_guesses,
+                                 n_guesses_doubles=None):
     """
-    Use the provided guess function to find a particular number of guesses
-    in the passed ADC matrix. If n_guesses_doubles is not None, this is
-    number is always adhered to. Otherwise the number of doubles guesses
-    is adjusted to fill up whatever the singles guesses cannot provide
-    to reach n_guesses.
+    Obtain guesses by inspecting the diagonal matrix elements.
+    If n_guesses_doubles is not None, this is number is always adhered to.
+    Otherwise the number of doubles guesses is adjusted to fill up whatever
+    the singles guesses cannot provide to reach n_guesses.
     Internal function called from run_adc.
     """
     if n_guesses_doubles is not None and n_guesses_doubles > 0 \
@@ -392,23 +417,49 @@ def find_guesses(guessfctn, matrix, n_guesses, n_guesses_doubles=None):
                          "method has a doubles block (i.e. it is *not* ADC(0), "
                          "ADC(1) or a variant thereof.")
 
+    # Determine guess function
+    guess_function = {"any": guesses_any, "singlet": guesses_singlet,
+                      "triplet": guesses_triplet,
+                      "spin_flip": guesses_spin_flip}[kind]
+
     # Determine number of singles guesses to request
     n_guess_singles = n_guesses
     if n_guesses_doubles is not None:
         n_guess_singles = n_guesses - n_guesses_doubles
-    singles_guesses = guessfctn(matrix, n_guess_singles, block="s")
+    singles_guesses = guess_function(matrix, n_guess_singles, block="s")
 
+    doubles_guesses = []
     if "d" in matrix.blocks:
         # Determine number of doubles guesses to request if not
         # explicitly specified
         if n_guesses_doubles is None:
             n_guesses_doubles = n_guesses - len(singles_guesses)
-        doubles_guesses = guessfctn(matrix, n_guesses_doubles, block="d")
-    else:
-        doubles_guesses = []
+        if n_guesses_doubles > 0:
+            doubles_guesses = guess_function(matrix, n_guesses_doubles, block="d")
 
     total_guesses = singles_guesses + doubles_guesses
     if len(total_guesses) < n_guesses:
         raise RuntimeError("Less guesses found than requested: {} found, "
                            "{} requested".format(len(total_guesses), n_guesses))
     return total_guesses
+
+
+def setup_solver_printing(solmethod_name, matrix, kind, default_print,
+                          output=None):
+    """
+    Setup default printing for solvers. Internal function called from run_adc.
+    """
+    kstr = " "
+    if kind != "any":
+        kstr = " " + kind
+    method_name = f"{matrix}"
+    if hasattr(matrix, "method"):
+        method_name = matrix.method.name
+
+    if output is not None:
+        print(f"Starting {method_name}{kstr} {solmethod_name} ...",
+              file=output)
+
+        def inner_callback(state, identifier):
+            default_print(state, identifier, output)
+        return inner_callback

--- a/extension/export_AdcMatrix.cc
+++ b/extension/export_AdcMatrix.cc
@@ -33,8 +33,6 @@ static py::tuple AdcMatrix_shape(const AdcMatrix& self) {
   return shape_tuple(self.shape());
 }
 
-static size_t AdcMatrix__len__(const AdcMatrix& self) { return self.shape()[0]; }
-
 static py::list AdcMatrix_blocks(const AdcMatrix& self) {
   py::list ret;
   for (auto& str : self.blocks()) {
@@ -70,7 +68,6 @@ void export_AdcMatrix(py::module& m) {
         .def("has_block", &AdcMatrix::has_block)
         .def_property_readonly("shape", &AdcMatrix_shape)
         .def("block_spaces", &AdcMatrix::block_spaces)
-        .def("__len__", &AdcMatrix__len__)
         .def_property_readonly("blocks", &AdcMatrix_blocks)
         .def("compute_matvec", &AdcMatrix::compute_matvec)
         .def_property_readonly(

--- a/extension/export_OneParticleOperator.cc
+++ b/extension/export_OneParticleOperator.cc
@@ -113,7 +113,10 @@ void export_OneParticleOperator(py::module& m) {
         .def("set_zero_block", set_zero_block_1,
              "Set a block of the matrix (e.g. o1o1, o1v1) to be explicitly zero.")
         .def("is_zero_block", &OneParticleOperator::is_zero_block)
-        .def("copy", &OneParticleOperator::copy)
+        .def("copy", &OneParticleOperator::copy,
+             "Return a deep copy of this OneParticleOperator.\n\nThis can be used to "
+             "conveniently add tensor corrections on top of existing OneParticleOperator "
+             "objects.")
         .def_property_readonly("is_symmetric", &OneParticleOperator::is_symmetric)
         .def_property_readonly("cartesian_transform",
                                &OneParticleOperator::cartesian_transform)

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,6 @@ filterwarnings =
 	ignore:Using or importing the ABCs from:DeprecationWarning
 	ignore:np.asscalar\(a\) is deprecated:DeprecationWarning
 	ignore:time.clock has been deprecated:DeprecationWarning
+	ignore:invalid escape sequence:DeprecationWarning
 norecursedirs = 
 	adcc/testdata/adcc-testdata
-


### PR DESCRIPTION
Datastructure to transparently view only the singles or doubles block of a bigger ADC matrix. Works with the Jacobi-Davidson. Others have not been tested, but should work as well.

Does not work for the doubles part because right now AmplitudeVector assumes that the first block is the singles block (and if we zoom into doubles only than the first block is the doubles block). I'll not attempt to cure that for now, but just to keep that in mind.

Tests are coming ...