### PR TITLE
Update config for binder

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,13 +1,9 @@
 name: adcc37
 channels:
-  - conda-forge
-  - psi4
+  - adcc/label/dev
+  - psi4/label/dev
   - defaults
 dependencies:
   - python=3.7
   - psi4
-  - openblas
-  - pip
-  - pip:
-    - pybind11
-    - .
+  - adcc


### PR DESCRIPTION
We use the development versions of psi4 and adcc from conda. Closes #46.