### PR TITLE
Conda suggestions

### DIFF
--- a/conda/meta.yaml.in
+++ b/conda/meta.yaml.in
@@ -32,11 +32,11 @@ requirements:
   run:
     - {{ pin_compatible('python', max_pin='x.x') }}
     - {{ pin_compatible('mkl', max_pin='x') }}
-    - {{ pin_compatible('h5py', max_pin='x.x.x') }}
     - {{ pin_compatible('numpy', max_pin='x.x') }}
-    - {{ pin_compatible('scipy', max_pin='x') }}
-    - {{ pin_compatible('matplotlib', max_pin='x') }}
-    - {{ pin_compatible('tqdm', max_pin='x') }}
+    - h5py >=2.9
+    - scipy >=1.2
+    - matplotlib >=3.0
+    - tqdm >=4.30
 
 test:
   imports:


### PR DESCRIPTION
Some suggestions to hopefully solve https://github.com/psi4/psi4/pull/1848.

- Output of failing run on Azure: https://dev.azure.com/psi4/psi4/_build/results?buildId=1779&view=logs&j=96451287-da82-57a8-2c11-8da7db9ab71a&t=41b51342-9bfb-52c2-7efb-0050141a3f7e

My rationale for the change:
- We need HDF5 only via h5py. Any version of h5py above the specified boundary should be good. No need to pin.
- Same for tiqn, matplotlib, scipy.
- HDF5 now pinned to a version compatible with chemps2

Any other suggestions?