### PR TITLE
Stop installing stdlib

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -17,6 +17,4 @@ recursive-include extension/adccore/include/adcc/ *.hh
 include adcc/lib/libadccore.so
 include adcc/lib/libadccore.dylib
 include adcc/lib/libadccore.*.dylib
-include adcc/lib/libstdc++.so.*
-include adcc/lib/libc++.so.*
 include adcc/lib/libadccore_LICENSE

--- a/extension/AdcCore.py
+++ b/extension/AdcCore.py
@@ -153,15 +153,9 @@ class AdcCore:
             else:
                 features = []
 
-        skip_stdlib = False
-        if os.environ.get("CONDA_BUILD", None) == "1":
-            # Do not install stdlib in conda builds
-            # TODO I'm not too big a fan of this, but I don't have a better idea
-            skip_stdlib = True
-
         build_dir = join(self.source_dir, "build")
         build_adccore.build_install(build_dir, self.install_dir,
-                                    skip_stdlib=skip_stdlib, features=features)
+                                    features=features, skip_stdlib=True)
 
     def build_documentation(self):
         """Build adccore documentation. Only valid if has_source is true"""


### PR DESCRIPTION
Doesn’t work with Conda anyway and for the adccore binaries we build with such an old version of glibc and libstdc++ that basically all relevant Debian and Ubuntu OSes are directly supported.