### PR TITLE
Fix small inconsistencies in ExcitedStates

### DIFF
--- a/adcc/ExcitedStates.py
+++ b/adcc/ExcitedStates.py
@@ -348,8 +348,8 @@ class ExcitedStates:
             ["eV", "au", "nm", "cm-1"]
         yaxis : str
             Quantity to plot on the y-Axis. Options are "cross_section",
-            "osc_strength", "dipole" (plots norm of transition dipole),
-            "rotational_strength" (ECD spectrum with rotational strength)
+            "oscillator_strength", "dipole" (plots norm of transition dipole),
+            "rotatory_strengths" (ECD spectrum with rotational strength),
         width : float, optional
             Gaussian broadening standard deviation or Lorentzian broadening
             gamma parameter. The value should be given in atomic units
@@ -379,7 +379,7 @@ class ExcitedStates:
         else:
             raise ValueError("Unknown xaxis specifier: {}".format(xaxis))
 
-        if yaxis in ["osc", "osc_strength", "oscillator_strength", "f"]:
+        if yaxis in ["osc", "oscillator_strength", "f"]:
             absorption = self.oscillator_strengths
             ylabel = "Oscillator strengths (au)"
         elif yaxis in ["dipole", "dipole_norm", "μ"]:


### PR DESCRIPTION
I think there are a few inconsistencies in ExcitedStates, for example that we only allow using the length gauge for the plot_spectrum. Also the plot_spectrum function is getting a bit messy. I'll try to correct this here.

Some questions to @maxscheurer:
- What gauge is used for our rotatory strengths? Always velocity, right?
- Also do you have a good reference (paper, textbook) for the rotatory strength calculation. I think we should probably add one in the code.