### PR TITLE
Install CPPE directly from pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
 
 install:
   - pip3 install pyscf
-  - pip3 install git+https://github.com/maxscheurer/cppe.git
+  - pip3 install cppe
   - pip3 install --verbose -r requirements.txt
 script: python3 setup.py test -a '--cov=adcc'
 


### PR DESCRIPTION
Since `pyscf` 1.7.3 was pushed to `pip` two days ago, the CI should work again with PE.
Closes #72 