### PR TITLE
Downgrade 10.14 XCode version in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ jobs:
     - python: 3.8
     - os: osx
       language: ruby
-      osx_image: xcode11.1  # macos 10.14
+      osx_image: xcode10.2  # macos 10.14
 
 deploy:  # Note: This will only deploy sdist on linux!
   skip_cleanup: true


### PR DESCRIPTION
To reach consistency with the build setup for `adccore`, this PR downgrades XCode on macOS to `10.2`.