### PR TITLE
Extend documentation of `memory_pool`.

### DIFF
--- a/adcc/memory_pool.py
+++ b/adcc/memory_pool.py
@@ -37,7 +37,9 @@ class MemoryPool(libadcc.AdcMemory):
         Parameters
         ----------
         max_memory : int
-            Estimate for the maximally employed memory
+            Estimate for the maximally employed memory. Note that this value
+            is only effective if the allocator parameter is "libxm". and not
+            for "default" or "standard".
 
         tensor_block_size : int, optional
             This parameter roughly has the meaning of how many indices are handled


### PR DESCRIPTION
Extend documentation of `memory_pool` to clearify #86 .