### PR TITLE
Implement to_qcvars function

### DIFF
--- a/adcc/ExcitedStates.py
+++ b/adcc/ExcitedStates.py
@@ -719,6 +719,39 @@ class ExcitedStates:
                 ret.append(key)
         return ret
 
+    def to_qcvars(self, properties=False, recurse=False):
+        """
+        Return a dictionary with property keys compatible to a Psi4 wavefunction
+        or a QCEngine Atomicresults object.
+        """
+        name = self.method.name.upper()
+
+        qcvars = {
+            "EXCITATION KIND": self.kind.upper(),
+            "NUMBER OF EXCITED STATES": len(self.excitation_energy),
+            f"{name} ITERATIONS": self.n_iter,
+            f"{name} EXCITATION ENERGIES": self.excitation_energy,
+        }
+
+        if properties:
+            qcvars.update({
+                # Transition properties
+                f"{name} TRANSITION DIPOLES (LEN)": self.transition_dipole_moment,
+                f"{name} TRANSITION DIPOLES (VEL)": self.transition_dipole_moment_velocity,  # noqa: E501
+                f"{name} OSCILLATOR STRENGTHS (LEN)": self.oscillator_strength,
+                f"{name} OSCILLATOR STRENGTHS (VEL)": self.oscillator_strength_velocity,  # noqa: E501
+                f"{name} ROTATIONAL STRENGTHS (VEL)": self.rotatory_strength,
+                #
+                # State properties
+                f"{name} STATE DIPOLES": self.state_dipole_moment
+            })
+
+        if recurse:
+            mpvars = self.ground_state.to_qcvars(properties, recurse=True,
+                                                 maxlevel=self.method.level)
+            qcvars.update(mpvars)
+        return qcvars
+
     @property
     def excitations(self):
         """

--- a/adcc/ReferenceState.py
+++ b/adcc/ReferenceState.py
@@ -189,6 +189,16 @@ class ReferenceState(libadcc.ReferenceState):
                     for space in self.mospaces.subspaces_virtual)
         return eHOMO < eLUMO
 
+    def to_qcvars(self, properties=False, recurse=False):
+        """
+        Return a dictionary with property keys compatible to a Psi4 wavefunction
+        or a QCEngine Atomicresults object.
+        """
+        qcvars = {"HF TOTAL ENERGY": self.energy_scf, }
+        if properties:
+            qcvars["HF DIPOLE"] = self.dipole_moment
+        return qcvars
+
     @property
     def density(self):
         """


### PR DESCRIPTION
Adding to_qcvars function, which could serve https://github.com/MolSSI/QCEngine/pull/277.

Actually getting this to be useful for Psi4 is not so easy, so I would not bother, but this poses the question why to even have this function in the first place at it might be pretty specific to QCEngine. On the other hand this allows us to add new properties to adcc and make them available to QCEngine without the need to modify code in that repo all the time, which is probably easier to maintain.

@maxscheurer Thoughts?