### PR TITLE
Adapt AdcMemory for libxm

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,8 +55,10 @@ jobs:
           python -m pip install --user pyscf cppe wheel
           python -m pip install --user -r requirements.txt -v
       #
-      - name: Run python tests
+      - name: Run python tests with std allocator
         run: python setup.py test -a '--cov=adcc'
+      - name: Run reduced python tests with libxm
+        run: python setup.py test -a '--allocator=libxm -k "TestFunctionality and h2o_sto3g"'
       - name: Run C++ tests
         run: python setup.py cpptest -v
       #

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,13 @@ jobs:
         run: |
           mkdir $HOME/.adcc/
           echo 'coverage = True' > $HOME/.adcc/siteconfig.py
+      - name: Hard-code download url for MacOS
+        run: |
+          echo "libtensor_url = \"$BASE_URL/$VERSION_URL\"" >> $HOME/.adcc/siteconfig.py
+        env:
+          BASE_URL: https://github.com/adc-connect/libtensor/releases/download
+          VERSION_URL: v3.0.1/libtensorlight-3.0.1-macosx_10_15_x86_64.tar.gz
+        if: contains( matrix.os, 'macos')
       - name: Install python dependencies
         run: |
           export PATH="/usr/local/opt/ccache/libexec:$PATH"

--- a/adcc/conftest.py
+++ b/adcc/conftest.py
@@ -21,7 +21,6 @@
 ##
 ## ---------------------------------------------------------------------
 import os
-
 import pytest
 
 from .testdata.cache import TestdataCache
@@ -61,6 +60,10 @@ def pytest_addoption(parser):
         "--skip-update", default=False, action="store_true",
         help="Skip updating testdata"
     )
+    parser.addoption(
+        "--allocator", default="standard", choices=["standard", "libxm"],
+        help="Allocator to use for the tests"
+    )
 
 
 def pytest_collection_modifyitems(config, items):
@@ -85,3 +88,9 @@ def pytest_collection(session):
 def pytest_runtestloop(session):
     if os.environ.get("CI", "false") == "true":
         setup_continuous_integration(session)
+    if session.config.option.allocator != "standard":
+        import adcc
+
+        allocator = session.config.option.allocator
+        adcc.memory_pool.initialise(allocator=allocator)
+        print(f"Using allocator: {allocator}")

--- a/conda/meta.yaml.in
+++ b/conda/meta.yaml.in
@@ -10,10 +10,10 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - python {{ python }}
-    - libtensorlight
+    - libtensorlight >=3.0.1
   host:
     - python {{ python }}
-    - libtensorlight
+    - libtensorlight >=3.0.1
     - pybind11 >=2.6
     # Testing:
     - pytest
@@ -31,7 +31,7 @@ requirements:
     - pandas >=0.25.0
   run:
     - {{ pin_compatible('python', max_pin='x.x') }}
-    - libtensorlight
+    - libtensorlight >=3.0.1
     - numpy >=1.14
     - h5py >=2.9
     - scipy >=1.2

--- a/libadcc/AdcMemory.cc
+++ b/libadcc/AdcMemory.cc
@@ -20,103 +20,62 @@
 #include "AdcMemory.hh"
 #include "exceptions.hh"
 #include <algorithm>
-#include <libtensor/metadata.h>
 
 // Change visibility of libtensor singletons to public
 #pragma GCC visibility push(default)
 #include <libtensor/core/allocator.h>
 #include <libtensor/core/batching_policy_base.h>
+#include <libtensor/expr/btensor/eval_btensor.h>
+#include <libtensor/metadata.h>
 #pragma GCC visibility pop
 
 namespace libadcc {
+namespace {
+bool libtensor_has_libxm() {
+  const std::vector<std::string>& libtensor_features = libtensor::metadata::features();
+  const auto it =
+        std::find(libtensor_features.begin(), libtensor_features.end(), "libxm");
+  return it != libtensor_features.end();
+}
+}  // namespace
 
 AdcMemory::AdcMemory()
-      : m_allocator("none"),
+      : m_max_block_size(0),
+        m_allocator("none"),
         m_initialise_called(false),
-        m_max_memory(0),
-        m_pagefile_directory{""},
-        m_tbs_param(0) {
-  // Just some value: >4GB is quite usual today and should get the setup right.
-  // ... and anyway this limit is not really a hard limit for the std::allocator
-  // anyway, since it plainly allocates memory on the system until we run out.
-  const size_t max_memory = 4ul * 1024ul * 1024ul * 1024ul;
-
-  // A tbs_param of 16 should be a good default.
-  const size_t tbs_param = 16;
-
-  initialise("", max_memory, tbs_param, "standard");
+        m_pagefile_directory{""} {
+  initialise("", 16, "standard");
 
   // Make sure we can call initialise once more
   m_initialise_called = false;
 }
 
-void AdcMemory::initialise(std::string pagefile_directory, size_t max_memory,
-                           size_t tbs_param, std::string allocator) {
-  if (max_memory == 0) {
-    throw invalid_argument("A max_memory value of 0 is not valid.");
-  }
-  if (tbs_param == 0) {
-    throw invalid_argument("A tbs_param value of 0 is not valid.");
-  }
+void AdcMemory::initialise(std::string pagefile_directory, size_t max_block_size,
+                           std::string allocator) {
   if (m_initialise_called) {
     throw invalid_argument("Cannot initialise AdcMemory object twice.");
   }
 
   m_initialise_called  = true;
-  m_max_memory         = max_memory;
   m_pagefile_directory = pagefile_directory;
-  m_tbs_param          = tbs_param;
-
-  //
-  // Determine initialisation parameters
-  //
-  // Our principle unit of memory is the employed scalar type,
-  // so our memory calculations will be based on that.
-  const size_t memunit = sizeof(scalar_type);
-
-  // Ideally our largest tensor block should be large enough to fit a few of the
-  // block size parameters. Our rationale here is that we have typically
-  // no more than tensors of rank 6
-  const size_t tbs3               = tbs_param * tbs_param * tbs_param;
-  const size_t largest_block_size = tbs3 * tbs3;
-
-  if (largest_block_size * memunit > max_memory) {
-    throw invalid_argument("At least " + std::to_string(largest_block_size * memunit) +
-                           " bytes of memory need to be requested.");
-  }
-
-  const bool has_libxm = [] {
-    const std::vector<std::string>& libtensor_features = libtensor::metadata::features();
-    const auto it =
-          std::find(libtensor_features.begin(), libtensor_features.end(), "libxm");
-    return it != libtensor_features.end();
-  }();
-
-  if (allocator == "default") {
-    // Preference is 1. libxm 2. standard
-    allocator = has_libxm ? "libxm" : "standard";
-  }
+  m_max_block_size     = max_block_size;
 
   if (allocator == "standard") {
-  } else if (allocator == "libxm" && has_libxm) {
+  } else if (allocator == "libxm" && libtensor_has_libxm()) {
   } else {
     throw invalid_argument("A memory allocator named '" + allocator +
                            "' is not known to adcc. Perhaps it is not compiled in.");
   }
 
   shutdown();  // Shutdown previously initialised allocator (if any)
-  libtensor::allocator<double>::init(
-        allocator,
-        tbs_param,                     // Exponential base of data block size
-        tbs_param * memunit,           // Smallest data block size in bytes
-        largest_block_size * memunit,  // Largest data block size in bytes
-        max_memory,                    // Memory limit in bytes
-        pagefile_directory.c_str()     // Prefix to page file path.
-  );
+  libtensor::allocator<double>::init(allocator, pagefile_directory.c_str());
   m_allocator = allocator;
 
-  // Set initial batch size
-  set_contraction_batch_size(max_memory / tbs3 / tbs_param / 3);
+  // Set initial batch size ... value empirically determined to be reasonable
+  set_contraction_batch_size(21870);
+
+  // Enable libxm contraction backend if libxm allocator is used
+  libtensor::expr::eval_btensor<double>::use_libxm(allocator == "libxm");
 }
 
 size_t AdcMemory::contraction_batch_size() const {

--- a/libadcc/MoSpaces.cc
+++ b/libadcc/MoSpaces.cc
@@ -446,7 +446,7 @@ MoSpaces::MoSpaces(const HartreeFockSolution_i& hf,
   //
   // Lambda to construct the blocks for a particular space.
   // Modifies map_block_start, map_block_spin, map_block_irrep
-  const size_t max_block_size = adcmem_ptr->tbs_param();
+  const size_t max_block_size = adcmem_ptr->max_block_size();
   auto construct_blocks_for   = [this, &map_index_sub_to_full, &irrep_of, &spin_of,
                                &subspace_of, &max_block_size](const std::string& space) {
     std::vector<size_t> fidx_of;

--- a/libadcc/Symmetry.cc
+++ b/libadcc/Symmetry.cc
@@ -118,10 +118,9 @@ Symmetry::Symmetry(std::shared_ptr<const MoSpaces> mospaces_ptr, const std::stri
                                 mospaces_ptr->map_block_start.at(ss)});
     } else {
       // ss is an extra axes
-      const size_t max_block_size = mospaces_ptr->adcmem_ptr()->tbs_param();
-      const size_t n_orbs_alpha   = itextra->second.first;
-      const size_t n_orbs_beta    = itextra->second.second;
-      const size_t n_orbs         = n_orbs_alpha + n_orbs_beta;
+      const size_t n_orbs_alpha = itextra->second.first;
+      const size_t n_orbs_beta  = itextra->second.second;
+      const size_t n_orbs       = n_orbs_alpha + n_orbs_beta;
 
       if (n_orbs_alpha == 0) {
         throw invalid_argument(
@@ -135,8 +134,8 @@ Symmetry::Symmetry(std::shared_ptr<const MoSpaces> mospaces_ptr, const std::stri
         splits_crude.push_back(n_orbs_alpha);
       }
 
-      const std::vector<size_t> blks =
-            construct_blocks(splits_crude, n_orbs, max_block_size);
+      const std::vector<size_t> blks = construct_blocks(
+            splits_crude, n_orbs, mospaces_ptr->adcmem_ptr()->max_block_size());
 
       m_axes.push_back(AxisInfo{ss, n_orbs_alpha, n_orbs_beta, blks});
     }

--- a/libadcc/TensorImpl.hh
+++ b/libadcc/TensorImpl.hh
@@ -110,7 +110,7 @@ class TensorImpl : public Tensor {
   std::string describe_expression(std::string stage = "unoptimised") const override;
 
   /** Convert object to btensor for use in libtensor functions. */
-  explicit operator libtensor::btensor<N, scalar_type>&() { return *libtensor_ptr(); }
+  explicit operator libtensor::btensor<N, scalar_type> &() { return *libtensor_ptr(); }
 
   /** Return inner btensor object
    *

--- a/libadcc/pyiface/export_AdcMemory.cc
+++ b/libadcc/pyiface/export_AdcMemory.cc
@@ -24,6 +24,7 @@
 
 namespace libadcc {
 
+using namespace pybind11::literals;
 namespace py = pybind11;
 
 static std::string AdcMemory___repr__(const AdcMemory& self) {
@@ -31,51 +32,33 @@ static std::string AdcMemory___repr__(const AdcMemory& self) {
 
   ss << "AdcMemory(allocator=" << self.allocator() << ", ";
   if (self.allocator() != "standard") {
-    double mem_mb = static_cast<double>(self.max_memory()) / 1024. / 1024.;
-    ss << "max_memory=" << mem_mb << "MiB, ";
     ss << "pagefile_directory=" << self.pagefile_directory() << ", ";
   }
-  ss << "tensor_block_size=" << self.tbs_param();
-  ss << ", contraction_batch_size=" << self.contraction_batch_size() << ")";
+  ss << "contraction_batch_size=" << self.contraction_batch_size() << ", ";
+  ss << "max_block_size=" << self.max_block_size() << ")";
   return ss.str();
 }
 
 void export_AdcMemory(py::module& m) {
-  // boost::noncopyable
   py::class_<AdcMemory, std::shared_ptr<AdcMemory>>(
         m, "AdcMemory",
         "Class controlling the memory allocations for adcc ADC calculations. Python "
-        "binding to "
-        ":cpp:class:`libadcc::AdcMemory`.")
+        "binding to :cpp:class:`libadcc::AdcMemory`.")
         .def(py::init<>())
         .def_property_readonly("allocator", &AdcMemory::allocator,
                                "Return the allocator to which the class is initialised.")
-        .def_property_readonly("max_memory", &AdcMemory::max_memory,
-                               "Return the max_memory parameter value to which the class "
-                               "was initialised.\nNote: This value is only a meaningful "
-                               "upper bound if allocator != \"standard\"")
         .def_property_readonly("pagefile_directory", &AdcMemory::pagefile_directory,
                                "Return the pagefile_directory value:\nNote: This value "
                                "is only meaningful if allocator != \"standard\"")
-        .def_property_readonly("tensor_block_size", &AdcMemory::tbs_param,
-                               "Return the tensor_block_size parameter.")
+        .def_property_readonly(
+              "max_block_size", &AdcMemory::max_block_size,
+              "Return the maximal block size a tenor may have along each axis.")
         .def_property("contraction_batch_size", &AdcMemory::contraction_batch_size,
                       &AdcMemory::set_contraction_batch_size,
                       "Get or set the batch size for contraction, i.e. the number of "
-                      "blocks handled simultaneously in a tensor contraction.")
-        .def("initialise", &AdcMemory::initialise,
-             "Initialise the adcc memory management.\n\n"
-             "@param   max_memory   Estimate for the maximally employed memory\n"
-             "@param tensor_block_size   This parameter roughly has the meaning\n"
-             "                           of how many indices are handled together\n"
-             "                           on operations. A good value is 16 for most\n"
-             "                           nowaday CPU cachelines.\n"
-             "@param pagefile_prefix     Directory prefix for storing temporary\n"
-             "                           cache files.\n"
-             "@param allocator   The allocator to be used. Valid values are \"libxm\",\n"
-             "                   \"libvmm\", \"standard\" and \"default\", where "
-             "\"default\"\n"
-             "                   uses a default chosen from the first three.")
+                      "elements handled simultaneously in a tensor contraction.")
+        .def("initialise", &AdcMemory::initialise, "pagefile_directory"_a,
+             "max_block_size"_a, "allocator"_a)
         .def("__repr__", &AdcMemory___repr__)
         //
         ;

--- a/libadcc/tests/MoIndexTranslationTest.cc
+++ b/libadcc/tests/MoIndexTranslationTest.cc
@@ -36,7 +36,7 @@ TEST_CASE("Test MoIndexTranslation", "[MoIndexTranslation]") {
   SECTION("Block size 16") {
     const HFSolutionMock& tested = hf_h2o;
     const size_t block_size      = 16;
-    adcmem_ptr->initialise("/tmp", 1000ul * 1000ul * 1000ul, block_size, "standard");
+    adcmem_ptr->initialise("/tmp", block_size, "standard");
     std::shared_ptr<MoSpaces> mospaces_ptr(new MoSpaces(tested, adcmem_ptr, {}, {}, {}));
 
     SECTION("Space o1o1") {
@@ -231,7 +231,7 @@ TEST_CASE("Test MoIndexTranslation", "[MoIndexTranslation]") {
   SECTION("Block size 4") {
     const HFSolutionMock& tested = hf_h2o;
     const size_t block_size      = 4;
-    adcmem_ptr->initialise("/tmp", 1000ul * 1000ul * 1000ul, block_size, "standard");
+    adcmem_ptr->initialise("/tmp", block_size, "standard");
     std::shared_ptr<MoSpaces> mospaces_ptr(new MoSpaces(tested, adcmem_ptr, {}, {}, {}));
 
     SECTION("Space o1o1") {
@@ -363,7 +363,7 @@ TEST_CASE("Test MoIndexTranslation", "[MoIndexTranslation]") {
   SECTION("Scattered CVS space") {
     const HFSolutionMock& tested = hf_h2o;
     const size_t block_size      = 16;
-    adcmem_ptr->initialise("/tmp", 1000ul * 1000ul * 1000ul, block_size, "standard");
+    adcmem_ptr->initialise("/tmp", block_size, "standard");
     std::shared_ptr<MoSpaces> mospaces_ptr(
           new MoSpaces(tested, adcmem_ptr, {3, 8}, {}, {}));
 

--- a/libadcc/tests/MoSpacesTest.cc
+++ b/libadcc/tests/MoSpacesTest.cc
@@ -31,7 +31,7 @@ TEST_CASE("Test MoSpaces", "[MoSpaces]") {
   SECTION("Block size 16") {
     const HFSolutionMock& tested = hf_h2o;
     const size_t block_size      = 16;
-    adcmem_ptr->initialise("/tmp", 1000ul * 1000ul * 1000ul, block_size, "standard");
+    adcmem_ptr->initialise("/tmp", block_size, "standard");
     MoSpaces mo(tested, adcmem_ptr, {}, {}, {});
 
     CHECK(mo.point_group == "C1");
@@ -81,7 +81,7 @@ TEST_CASE("Test MoSpaces", "[MoSpaces]") {
   SECTION("Block size 4") {
     const HFSolutionMock& tested = hf_h2o;
     const size_t block_size      = 4;
-    adcmem_ptr->initialise("/tmp", 1000ul * 1000ul * 1000ul, block_size, "standard");
+    adcmem_ptr->initialise("/tmp", block_size, "standard");
     MoSpaces mo(tested, adcmem_ptr, {}, {}, {});
 
     CHECK(mo.point_group == "C1");
@@ -125,7 +125,7 @@ TEST_CASE("Test MoSpaces", "[MoSpaces]") {
   SECTION("Block size 16, 1 core (lowest)") {
     const HFSolutionMock& tested = hf_h2o;
     const size_t block_size      = 16;
-    adcmem_ptr->initialise("/tmp", 1000ul * 1000ul * 1000ul, block_size, "standard");
+    adcmem_ptr->initialise("/tmp", block_size, "standard");
     MoSpaces mo(tested, adcmem_ptr, {0, 7}, {}, {});
 
     CHECK(mo.point_group == "C1");
@@ -175,7 +175,7 @@ TEST_CASE("Test MoSpaces", "[MoSpaces]") {
   SECTION("Block size 16, 1 core (scattered)") {
     const HFSolutionMock& tested = hf_h2o;
     const size_t block_size      = 16;
-    adcmem_ptr->initialise("/tmp", 1000ul * 1000ul * 1000ul, block_size, "standard");
+    adcmem_ptr->initialise("/tmp", block_size, "standard");
     MoSpaces mo(tested, adcmem_ptr, {3, 8}, {}, {});
 
     CHECK(mo.point_group == "C1");
@@ -225,7 +225,7 @@ TEST_CASE("Test MoSpaces", "[MoSpaces]") {
   SECTION("1 frozen virtual, highest") {
     const HFSolutionMock& tested = hf_h2o;
     const size_t block_size      = 16;
-    adcmem_ptr->initialise("/tmp", 1000ul * 1000ul * 1000ul, block_size, "standard");
+    adcmem_ptr->initialise("/tmp", block_size, "standard");
     MoSpaces mo(tested, adcmem_ptr, {}, {}, {6, 13});
 
     CHECK(mo.point_group == "C1");
@@ -275,7 +275,7 @@ TEST_CASE("Test MoSpaces", "[MoSpaces]") {
   SECTION("1 frozen virtual, scattered") {
     const HFSolutionMock& tested = hf_h2o;
     const size_t block_size      = 16;
-    adcmem_ptr->initialise("/tmp", 1000ul * 1000ul * 1000ul, block_size, "standard");
+    adcmem_ptr->initialise("/tmp", block_size, "standard");
     MoSpaces mo(tested, adcmem_ptr, {}, {}, {5, 11});
 
     CHECK(mo.point_group == "C1");
@@ -325,7 +325,7 @@ TEST_CASE("Test MoSpaces", "[MoSpaces]") {
   SECTION("Block size 16, 1 frozen core (lowest)") {
     const HFSolutionMock& tested = hf_h2o;
     const size_t block_size      = 16;
-    adcmem_ptr->initialise("/tmp", 1000ul * 1000ul * 1000ul, block_size, "standard");
+    adcmem_ptr->initialise("/tmp", block_size, "standard");
     MoSpaces mo(tested, adcmem_ptr, {}, {0, 7}, {});
 
     CHECK(mo.point_group == "C1");
@@ -375,7 +375,7 @@ TEST_CASE("Test MoSpaces", "[MoSpaces]") {
   SECTION("Block size 16, 1 frozen core (scattered)") {
     const HFSolutionMock& tested = hf_h2o;
     const size_t block_size      = 16;
-    adcmem_ptr->initialise("/tmp", 1000ul * 1000ul * 1000ul, block_size, "standard");
+    adcmem_ptr->initialise("/tmp", block_size, "standard");
     MoSpaces mo(tested, adcmem_ptr, {}, {6, 8}, {});
 
     CHECK(mo.point_group == "C1");
@@ -425,7 +425,7 @@ TEST_CASE("Test MoSpaces", "[MoSpaces]") {
   SECTION("Block size 16, 1 frozen core, 1 core, 1 frozen virtual (logical)") {
     const HFSolutionMock& tested = hf_h2o;
     const size_t block_size      = 16;
-    adcmem_ptr->initialise("/tmp", 1000ul * 1000ul * 1000ul, block_size, "standard");
+    adcmem_ptr->initialise("/tmp", block_size, "standard");
     MoSpaces mo(tested, adcmem_ptr, {1, 8}, {0, 7}, {6, 13});
 
     CHECK(mo.point_group == "C1");
@@ -487,7 +487,7 @@ TEST_CASE("Test MoSpaces", "[MoSpaces]") {
   SECTION("Block size 16, 1 frozen core, 1 core, 1 frozen virtual (scattered)") {
     const HFSolutionMock& tested = hf_h2o;
     const size_t block_size      = 16;
-    adcmem_ptr->initialise("/tmp", 1000ul * 1000ul * 1000ul, block_size, "standard");
+    adcmem_ptr->initialise("/tmp", block_size, "standard");
     //                               core   fzcore   fzvirt
     MoSpaces mo(tested, adcmem_ptr, {3, 9}, {1, 8}, {4, 10});
 

--- a/setup.py
+++ b/setup.py
@@ -268,7 +268,7 @@ def assets_most_recent_release(project):
     url = f"https://api.github.com/repos/{project}/releases"
     with tempfile.TemporaryDirectory() as tmpdir:
         fn = tmpdir + "/releases.json"
-        for _ in range(3):
+        for _ in range(10):
             status = request_urllib(url, fn)
             if 200 <= status < 300:
                 break

--- a/setup.py
+++ b/setup.py
@@ -352,6 +352,7 @@ def libadcc_extension():
         search_system=True,
         coverage=False,
         libtensor_autoinstall="~/.local",
+        libtensor_url=None,
     )
 
     if sys.platform == "darwin" and is_conda_build():
@@ -383,7 +384,7 @@ def libadcc_extension():
 
     # Keep track whether libtensor has been found
     found_libtensor = "tensorlight" in flags["libraries"]
-    lt_min_version = "2.9.9"
+    lt_min_version = "3.0.1"
 
     if not found_libtensor:
         if flags["search_system"]:  # Find libtensor on the OS using pkg-config
@@ -392,26 +393,30 @@ def libadcc_extension():
 
         # Try to download libtensor if not on the OS
         if (cflags is None or libs is None) and flags["libtensor_autoinstall"]:
-            assets = assets_most_recent_release("adc-connect/libtensor")
-            url = []
-            if sys.platform == "linux":
-                url = [asset for asset in assets if "-linux_x86_64" in asset]
-            elif sys.platform == "darwin":
-                url = [asset for asset in assets
-                       if "-macosx_" in asset and "_x86_64" in asset]
+            if flags["libtensor_url"]:
+                url = flags["libtensor_url"]
             else:
-                raise AssertionError("Should not get to download for "
-                                     "unspported platform.")
-            if len(url) != 1:
-                raise RuntimeError(
-                    "Could not find a libtensor version to download. "
-                    "Check your platform is supported and if in doubt see the "
-                    "adcc installation instructions "
-                    "(https://adc-connect.org/latest/installation.html)."
-                )
+                assets = assets_most_recent_release("adc-connect/libtensor")
+                url = []
+                if sys.platform == "linux":
+                    url = [asset for asset in assets if "-linux_x86_64" in asset]
+                elif sys.platform == "darwin":
+                    url = [asset for asset in assets
+                           if "-macosx_" in asset and "_x86_64" in asset]
+                else:
+                    raise AssertionError("Should not get to download for "
+                                         "unspported platform.")
+                if len(url) != 1:
+                    raise RuntimeError(
+                        "Could not find a libtensor version to download. "
+                        "Check your platform is supported and if in doubt see the "
+                        "adcc installation instructions "
+                        "(https://adc-connect.org/latest/installation.html)."
+                    )
+                url = url[0]
 
             destdir = os.path.expanduser(flags["libtensor_autoinstall"])
-            install_libtensor(url[0], destdir)
+            install_libtensor(url, destdir)
             os.environ['PKG_CONFIG_PATH'] += f":{destdir}/lib/pkgconfig"
             cflags, libs = search_with_pkg_config("libtensorlight", lt_min_version)
             assert cflags is not None and libs is not None


### PR DESCRIPTION
Needs the changes from https://github.com/adc-connect/libtensor/pull/9.

# Progress
- [x] Tests pass with libxm allocator locally
- [x] Test libxm allocator on a big system
- [x] Test libxm allocator on a really big system (i.e. exceeding the RAM of a machine)
- [x] Add to docs how to use libxm allocator

@maxscheurer Feel free to play with it with a nice example. Libxm seems to write everything to disk and prefetch as it goes. That means that the memory requirement is super small, but also that it's only worth it if you have a fast disk and a calculation that no longer fits into your available RAM. But in that sense it closes a gap that adcc still has.