### PR TITLE
Test conda build with dev lt

### DIFF
--- a/scripts/upload_to_anaconda.sh
+++ b/scripts/upload_to_anaconda.sh
@@ -34,4 +34,4 @@ conda install conda-build anaconda-client conda-verify --yes
 # conda config --append channels pyscf
 
 # Running build and deployment
-conda build conda -m conda/config_${LABEL}.yaml -c adcc/label/main -c defaults -c conda-forge --user adcc --token $ANACONDA_TOKEN --label $LABEL
+conda build conda -m conda/config_${LABEL}.yaml -c adcc/label/dev -c defaults -c conda-forge --user adcc --token $ANACONDA_TOKEN --label $LABEL


### PR DESCRIPTION
Just a dummy PR to test the dev-deployed lt version (fixing current conda build issues on macOS hopefully)
See [here](https://github.com/adc-connect/libtensor/pull/11) for details.