### PR TITLE
Fix AmplitudeVector and coveralls

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,7 +88,7 @@ jobs:
           pip install coveralls
           sudo gem install coveralls-lcov
           coveralls-lcov -v -n coverage.info > coverage.json
-          coveralls --merge=coverage.json
+          coveralls --service=github --merge=coverage.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   #

--- a/adcc/AmplitudeVector.py
+++ b/adcc/AmplitudeVector.py
@@ -46,6 +46,11 @@ class AmplitudeVector(dict):
             return self.__getitem__(key)
         raise AttributeError
 
+    def __setattr__(self, key, item):
+        if self.__contains__(key):
+            return self.__setitem__(key, item)
+        raise AttributeError
+
     @property
     def blocks(self):
         warnings.warn("The blocks attribute will change behaviour in 0.16.0.")
@@ -94,7 +99,7 @@ class AmplitudeVector(dict):
             else:
                 raise KeyError(index)
         else:
-            super().__setitem__(index, item)
+            return super().__setitem__(index, item)
 
     def copy(self):
         """Return a copy of the AmplitudeVector"""

--- a/adcc/test_AmplitudeVector.py
+++ b/adcc/test_AmplitudeVector.py
@@ -38,6 +38,8 @@ class TestAmplitudeVector(unittest.TestCase):
         v, w = vectors
         with pytest.raises(AttributeError):
             v.pph
+        with pytest.raises(AttributeError):
+            v.pph = w.ph
         # setattr with expression
         z = adcc.zeros_like(v)
         z.ph = v.ph + w.ph

--- a/adcc/test_AmplitudeVector.py
+++ b/adcc/test_AmplitudeVector.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+## vi: tabstop=4 shiftwidth=4 softtabstop=4 expandtab
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2021 by the adcc authors
+##
+## This file is part of adcc.
+##
+## adcc is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published
+## by the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## adcc is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with adcc. If not, see <http://www.gnu.org/licenses/>.
+##
+## ---------------------------------------------------------------------
+import pytest
+import unittest
+import numpy as np
+
+import adcc
+from adcc.testdata.cache import cache
+
+
+class TestAmplitudeVector(unittest.TestCase):
+    def test_functionality(self):
+        ground_state = adcc.LazyMp(cache.refstate["h2o_sto3g"])
+        matrix = adcc.AdcMatrix("adc2", ground_state)
+        vectors = [adcc.guess_zero(matrix) for i in range(2)]
+        for vec in vectors:
+            vec.set_random()
+        v, w = vectors
+        with pytest.raises(AttributeError):
+            v.pph
+        # setattr with expression
+        z = adcc.zeros_like(v)
+        z.ph = v.ph + w.ph
+        z -= w
+        np.testing.assert_allclose(
+            v.ph.to_ndarray(), z.ph.to_ndarray()
+        )


### PR DESCRIPTION
This PR fixes some weird behavior of the `AmplitudeVector` and coveralls upload.
`__setattr__` is now forwarded to `__setitem__`, in analogy to `__getattr__`

Test that would hit the previous error added. I'd vote for a `0.15.7` release after this fix, because this is a serious bug...