### PR TITLE
Fix bug with pyscf module import

### DIFF
--- a/adcc/OperatorIntegrals.py
+++ b/adcc/OperatorIntegrals.py
@@ -162,6 +162,9 @@ class OperatorIntegrals:
         is_symmetric : bool, optional
             if the imported operator is symmetric, by default True
         """
+        if not callable(ao_callback):
+            raise TypeError("ao_callback must be callable.")
+
         def process_operator(dm, callback=ao_callback, is_symmetric=is_symmetric):
             dm_ao = sum(dm.to_ao_basis())
             v_ao = callback(dm_ao)

--- a/adcc/backends/pyscf.py
+++ b/adcc/backends/pyscf.py
@@ -30,7 +30,7 @@ from ..exceptions import InvalidReference
 from ..ExcitedStates import EnergyCorrection
 
 from pyscf import ao2mo, gto, scf
-from pyscf.solvent import pol_embed, ddcosmo
+from pyscf.solvent import ddcosmo
 
 
 class PyScfOperatorIntegralProvider:
@@ -59,28 +59,38 @@ class PyScfOperatorIntegralProvider:
 
     @property
     def pe_induction_elec(self):
-        if hasattr(self.scfres, "with_solvent"):
-            if isinstance(self.scfres.with_solvent, pol_embed.PolEmbed):
-                def pe_induction_elec_ao(dm):
-                    return self.scfres.with_solvent._exec_cppe(
-                        dm.to_ndarray(), elec_only=True
-                    )[1]
-                return pe_induction_elec_ao
+        if not hasattr(self.scfres, "with_solvent"):
+            raise ValueError("Cannot compute PE induction for "
+                             "an SCF state without solvent.")
+        if not hasattr(self.scfres.with_solvent, "cppe_state"):
+            raise ValueError("Cannot compute PE induction for "
+                             "an SCF state without PE.")
+
+        def pe_induction_elec_ao(dm):
+            return self.scfres.with_solvent._exec_cppe(
+                dm.to_ndarray(), elec_only=True
+            )[1]
+        return pe_induction_elec_ao
 
     @property
     def pcm_potential_elec(self):
-        if hasattr(self.scfres, "with_solvent"):
-            if isinstance(self.scfres.with_solvent, ddcosmo.DDCOSMO):
-                def pcm_potential_elec_ao(dm):
-                    # Since eps (dielectric constant) is the only solvent parameter
-                    # in pyscf and there is no solvent data available in the
-                    # program, the user needs to adjust scfres.with_solvent.eps
-                    # manually to the optical dielectric constant (if non
-                    # equilibrium solvation is desired).
-                    return self.scfres.with_solvent._B_dot_x(
-                        dm.to_ndarray()
-                    )
-                return pcm_potential_elec_ao
+        if not hasattr(self.scfres, "with_solvent"):
+            raise ValueError("Cannot compute PCM potential for "
+                             "an SCF state without solvent.")
+        if not isinstance(self.scfres.with_solvent, ddcosmo.DDCOSMO):
+            raise ValueError("Cannot compute PCM potential for "
+                             "an SCF state without PCM.")
+
+        def pcm_potential_elec_ao(dm):
+            # Since eps (dielectric constant) is the only solvent parameter
+            # in pyscf and there is no solvent data available in the
+            # program, the user needs to adjust scfres.with_solvent.eps
+            # manually to the optical dielectric constant (if non
+            # equilibrium solvation is desired).
+            return self.scfres.with_solvent._B_dot_x(
+                dm.to_ndarray()
+            )
+        return pcm_potential_elec_ao
 
 
 # TODO: refactor ERI builder to be more general
@@ -177,7 +187,7 @@ class PyScfHFProvider(HartreeFockProvider):
     def environment(self):
         ret = None
         if hasattr(self.scfres, "with_solvent"):
-            if isinstance(self.scfres.with_solvent, pol_embed.PolEmbed):
+            if hasattr(self.scfres.with_solvent, "cppe_state"):
                 ret = "pe"
             elif isinstance(self.scfres.with_solvent, ddcosmo.DDCOSMO):
                 ret = "pcm"

--- a/adcc/backends/pyscf.py
+++ b/adcc/backends/pyscf.py
@@ -59,12 +59,10 @@ class PyScfOperatorIntegralProvider:
 
     @property
     def pe_induction_elec(self):
-        if not hasattr(self.scfres, "with_solvent"):
-            raise ValueError("Cannot compute PE induction for "
-                             "an SCF state without solvent.")
-        if not hasattr(self.scfres.with_solvent, "cppe_state"):
-            raise ValueError("Cannot compute PE induction for "
-                             "an SCF state without PE.")
+        try:
+            self.scfres.with_solvent.cppe_state
+        except AttributeError:
+            return None
 
         def pe_induction_elec_ao(dm):
             return self.scfres.with_solvent._exec_cppe(
@@ -75,11 +73,9 @@ class PyScfOperatorIntegralProvider:
     @property
     def pcm_potential_elec(self):
         if not hasattr(self.scfres, "with_solvent"):
-            raise ValueError("Cannot compute PCM potential for "
-                             "an SCF state without solvent.")
+            return None
         if not isinstance(self.scfres.with_solvent, ddcosmo.DDCOSMO):
-            raise ValueError("Cannot compute PCM potential for "
-                             "an SCF state without PCM.")
+            return None
 
         def pcm_potential_elec_ao(dm):
             # Since eps (dielectric constant) is the only solvent parameter

--- a/adcc/backends/test_backends_pcm.py
+++ b/adcc/backends/test_backends_pcm.py
@@ -15,7 +15,7 @@ from adcc.adc_pp.environment import block_ph_ph_0_pcm
 from adcc.AdcMatrix import AdcExtraTerm
 
 backends = [b for b in adcc.backends.available() if b in ["psi4", "pyscf"]]
-basissets = ["sto-3g", "ccpvdz"]
+basissets = ["sto3g", "ccpvdz"]
 methods = ["adc1"]
 
 
@@ -119,6 +119,10 @@ def remove_cavity_psi4():
 
 def psi4_run_pcm_hf(xyz, basis, charge=0, multiplicity=1, conv_tol=1e-12,
                     conv_tol_grad=1e-11, max_iter=150, pcm_options=None):
+    basis_map = {
+        "sto3g": "sto-3g",
+        "ccpvdz": "cc-pvdz",
+    }
     import psi4
 
     # needed for PE and PCM tests
@@ -134,7 +138,7 @@ def psi4_run_pcm_hf(xyz, basis, charge=0, multiplicity=1, conv_tol=1e-12,
 
     psi4.core.be_quiet()
     psi4.set_options({
-        'basis': basis,
+        'basis': basis_map[basis],
         'scf_type': 'pk',
         'e_convergence': conv_tol,
         'd_convergence': conv_tol_grad,

--- a/adcc/testdata/generate_psi4_data.py
+++ b/adcc/testdata/generate_psi4_data.py
@@ -6,6 +6,13 @@ import yaml
 import os
 
 
+basis_remap = {
+    "sto3g": "sto-3g",
+    "def2tzvp": "def2-tzvp",
+    "ccpvdz": "cc-pvdz",
+}
+
+
 def run_psi4_tdscf(xyz, basis, charge=0, multiplicity=1,
                    conv_tol=1e-12, conv_tol_grad=1e-11, max_iter=150,
                    pcm_options=None):
@@ -16,7 +23,7 @@ def run_psi4_tdscf(xyz, basis, charge=0, multiplicity=1,
         symmetry c1
     """)
     psi4.set_options({
-        'basis': basis,
+        'basis': basis_remap[basis],
         'scf_type': "pK",
         'e_convergence': conv_tol,
         'd_convergence': conv_tol_grad,
@@ -91,7 +98,7 @@ def dump_results(molecule, basis, **kwargs):
 
 
 def main():
-    basis_set = ["sto-3g", "cc-pvdz"]
+    basis_set = ["sto3g", "ccpvdz"]
     pcm_options = {"weight": 0.3, "pcm_method": "IEFPCM", "neq": True,
                    "solvent": "Water"}
     psi4_results = {}

--- a/adcc/testdata/generate_pyscf_data.py
+++ b/adcc/testdata/generate_pyscf_data.py
@@ -77,7 +77,7 @@ def dump_results(molecule, basis, **kwargs):
 
 
 def main():
-    basis_set = ["sto-3g", "cc-pvdz"]
+    basis_set = ["sto3g", "ccpvdz"]
     pcm_options = {"eps": 78.3553, "eps_opt": 1.78}
     pyscf_results = {}
     for basis in basis_set:

--- a/adcc/testdata/psi4_dump.yml
+++ b/adcc/testdata/psi4_dump.yml
@@ -1,17 +1,17 @@
-formaldehyde_sto-3g_pcm_adc1:
-  basis: sto-3g
+formaldehyde_sto3g_pcm_adc1:
+  basis: sto3g
   method: adc1
   molecule: formaldehyde
-  energy_scf: -112.35458302984613
+  energy_scf: -112.35458302984607
   lr_excitation_energy: [0.164670987, 0.360903879, 0.465492571, 0.50874055, 0.693857844]
   lr_osc_strength: [0.0, 0.01075, 0.34344, 0.0, 0.35858]
   ptlr_adcc_excitation_energy: [0.164676366, 0.360930626, 0.467575499, 0.508742077,
     0.694474733]
-formaldehyde_cc-pvdz_pcm_adc1:
-  basis: cc-pvdz
+formaldehyde_ccpvdz_pcm_adc1:
+  basis: ccpvdz
   method: adc1
   molecule: formaldehyde
-  energy_scf: -113.88427067069416
+  energy_scf: -113.88427067069375
   lr_excitation_energy: [0.178995043, 0.38176984, 0.388019451, 0.392159876, 0.435439339]
   lr_osc_strength: [0.0, 7.0e-05, 0.24871, 0.23489, 0.0]
   ptlr_adcc_excitation_energy: [0.179023803, 0.381851509, 0.389582948, 0.392594025,

--- a/adcc/testdata/pyscf_dump.yml
+++ b/adcc/testdata/pyscf_dump.yml
@@ -1,5 +1,5 @@
-formaldehyde_sto-3g_pcm_adc1:
-  basis: sto-3g
+formaldehyde_sto3g_pcm_adc1:
+  basis: sto3g
   method: adc1
   molecule: formaldehyde
   energy_scf: -112.35408506197172
@@ -7,11 +7,11 @@ formaldehyde_sto-3g_pcm_adc1:
   lr_osc_strength: [0.0, 0.01098, 0.34455, 0.0, 0.35987]
   ptlr_adcc_excitation_energy: [0.163957725, 0.360034834, 0.467270151, 0.509148683,
     0.693769922]
-formaldehyde_cc-pvdz_pcm_adc1:
-  basis: cc-pvdz
+formaldehyde_ccpvdz_pcm_adc1:
+  basis: ccpvdz
   method: adc1
   molecule: formaldehyde
-  energy_scf: -113.88287611072602
+  energy_scf: -113.88287611072613
   lr_excitation_energy: [0.177403519, 0.379894734, 0.386588779, 0.390625944, 0.435452412]
   lr_osc_strength: [0.0, 0.00012, 0.24985, 0.2374, 0.0]
   ptlr_adcc_excitation_energy: [0.177443175, 0.379990015, 0.388208087, 0.391106802,


### PR DESCRIPTION
In #132, `pyscf` backend does not work anymore when `cppe` is not present because of top-level module import.

This also got past me during code review 😄 