### PR TITLE
Remove old block style and other deprecations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,6 +110,7 @@ jobs:
         if: contains(matrix.os, 'ubuntu')
 
   deploy_documentation:
+    if: github.ref == 'refs/heads/master'
     needs: test
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,16 +119,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {version: '3.9', os: ubuntu-latest, documentation: False}
+          - {version: '3.11', os: ubuntu-latest, documentation: False}
+          - {version: '3.11', os: macos-13 , documentation: False}
     defaults:
       run:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v4
+      - name: Patch compiler in Conda environment file
+        if: contains( matrix.os, 'macos')
+        run: |
+          sed -E -i.bak "s;gcc_linux-64;clang_osx-64;g" conda/environment.yml
+          sed -E -i.bak "s;gxx_linux-64;clangxx_osx-64;g" conda/environment.yml
       - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: adcc-dev
-          environment-file: conda/environment_dev_linux.yml
+          environment-file: conda/environment.yml
           miniforge-variant: Mambaforge
           use-mamba: true
           miniforge-version: latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,21 +72,21 @@ jobs:
           python -m pytest adcc --allocator=libxm -k "TestFunctionality and h2o_sto3g"
       - name: Run C++ tests
         run: python setup.py cpptest -v
-      #
-      # TODO: sphinx.setup_command does not exist anymore,
-      # need to build docs differently
-      # - name: Dependencies for documentation
-      #   run: python -m pip install --user .[build_docs]
-      #   if: matrix.documentation
-      # - name: Build documentation
-      #   run: python setup.py build_docs
-      #   if: matrix.documentation
-      # - name: Upload documentation artefact
-      #   uses: actions/upload-artifact@v2
-      #   with:
-      #     name: documentation
-      #     path: build/sphinx/html
-      #   if: matrix.documentation
+      # Documentation build
+      - name: Dependencies for documentation
+        run: python -m pip install --user .[build_docs]
+        if: matrix.documentation
+      - name: Build documentation
+        run: |
+          cd docs && doxygen && cd ..
+          sphinx-build -M html docs build/sphinx
+        if: matrix.documentation
+      - name: Upload documentation artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: documentation
+          path: build/sphinx/html
+        if: matrix.documentation
       #
       - name: Upload coverage to codecov
         run: |
@@ -109,6 +109,22 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: contains(matrix.os, 'ubuntu')
 
+  deploy_documentation:
+    needs: test
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    # Specify runner + deployment step
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
   #
   # Test Conda Python
   #

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,11 +21,11 @@ jobs:
           - {version: '3.9', os: ubuntu-latest, documentation: False}
           - {version: '3.11', os: macos-13 , documentation: False}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.version }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:
@@ -124,8 +124,8 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: actions/checkout@v4
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: adcc-dev
           environment-file: conda/environment_dev_linux.yml
@@ -178,8 +178,8 @@ jobs:
     name: Code style
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       - name: Install dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,6 +110,7 @@ jobs:
         if: contains(matrix.os, 'ubuntu')
 
   deploy_documentation:
+    name: Deploy Documentation to Github Pages
     if: github.ref == 'refs/heads/master'
     needs: test
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,7 +82,7 @@ jobs:
           sphinx-build -M html docs build/sphinx
         if: matrix.documentation
       - name: Upload documentation artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: documentation
           path: build/sphinx/html
@@ -125,6 +125,8 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          artifact_name: documentation
   #
   # Test Conda Python
   #

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -153,8 +153,9 @@ jobs:
         run: |
           conda info
           conda list
-          # NOTE: pcmsolver not 'linked' with Psi4 1.8
+          CXXFLAGS="$(echo $CXXFLAGS | sed 's/-fvisibility-inlines-hidden //g')"
           pip install .[tests] --user
+          # NOTE: pcmsolver not 'linked' with Psi4 1.8
           pytest adcc -k "not pcm"
           # python setup.py cpptest -v  # TODO: currently doesn't compile...
       #

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,9 +82,8 @@ jobs:
           sphinx-build -M html docs build/sphinx
         if: matrix.documentation
       - name: Upload documentation artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
-          name: documentation
           path: build/sphinx/html
         if: matrix.documentation
       #
@@ -127,8 +126,6 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-        with:
-          artifact_name: documentation
   #
   # Test Conda Python
   #

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,8 +10,8 @@ jobs:
     name: Publish 📦 to PyPI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.9'
       - name: Install dependencies

--- a/adcc/AdcMatrix.py
+++ b/adcc/AdcMatrix.py
@@ -21,7 +21,6 @@
 ##
 ## ---------------------------------------------------------------------
 import libadcc
-import warnings
 import numpy as np
 
 from .LazyMp import LazyMp

--- a/adcc/AdcMatrix.py
+++ b/adcc/AdcMatrix.py
@@ -552,8 +552,8 @@ class AdcMatrixShifted(AdcMatrix):
             ret += self.shift * in_vec
         return ret
 
-    def diagonal(self, block=None):
-        out = super().diagonal(block)
+    def diagonal(self):
+        out = super().diagonal()
         out = out + self.shift  # Shift the diagonal
         return out
 

--- a/adcc/AdcMatrix.py
+++ b/adcc/AdcMatrix.py
@@ -256,7 +256,6 @@ class AdcMatrix(AdcMatrixlike):
         """
         return list(self.axis_spaces.keys())
 
-    @property
     def diagonal(self):
         """Return the diagonal of the ADC matrix"""
         return self.__diagonal

--- a/adcc/AdcMatrix.py
+++ b/adcc/AdcMatrix.py
@@ -164,7 +164,6 @@ class AdcMatrix(AdcMatrixlike):
                                       variant=variant)
                 for block, order in self.block_orders.items() if order is not None
             }
-            # TODO Rename to self.block in 0.16.0
             self.blocks = {bl: blocks[bl].apply for bl in blocks}
             if diagonal_precomputed:
                 self.__diagonal = diagonal_precomputed

--- a/adcc/AdcMatrix.py
+++ b/adcc/AdcMatrix.py
@@ -166,7 +166,7 @@ class AdcMatrix(AdcMatrixlike):
                 for block, order in self.block_orders.items() if order is not None
             }
             # TODO Rename to self.block in 0.16.0
-            self.blocks_ph = {bl: blocks[bl].apply for bl in blocks}
+            self.blocks = {bl: blocks[bl].apply for bl in blocks}
             if diagonal_precomputed:
                 self.__diagonal = diagonal_precomputed
             else:
@@ -185,16 +185,16 @@ class AdcMatrix(AdcMatrixlike):
         """
         if not isinstance(other, AdcExtraTerm):
             return NotImplemented
-        if not all(k in self.blocks_ph for k in other.blocks):
+        if not all(k in self.blocks for k in other.blocks):
             raise ValueError("Can only add to blocks of"
                              " AdcMatrix that already exist.")
         for sp in other.blocks:
-            orig_app = self.blocks_ph[sp]
+            orig_app = self.blocks[sp]
             other_app = other.blocks[sp].apply
 
             def patched_apply(ampl, original=orig_app, other=other_app):
                 return sum(app(ampl) for app in (original, other))
-            self.blocks_ph[sp] = patched_apply
+            self.blocks[sp] = patched_apply
         other_diagonal = sum(bl.diagonal for bl in other.blocks.values()
                              if bl.diagonal)
         self.__diagonal = self.__diagonal + other_diagonal
@@ -232,7 +232,7 @@ class AdcMatrix(AdcMatrixlike):
         """Update the cached data regarding the spaces of the ADC matrix"""
         self.axis_spaces = {}
         self.axis_lengths = {}
-        for block in diagonal.blocks_ph:
+        for block in diagonal.blocks:
             self.axis_spaces[block] = getattr(diagonal, block).subspaces
             self.axis_lengths[block] = np.prod([
                 self.mospaces.n_orbs(sp) for sp in self.axis_spaces[block]
@@ -250,27 +250,6 @@ class AdcMatrix(AdcMatrixlike):
         return self.shape[0]
 
     @property
-    def blocks(self):
-        # TODO Remove in 0.16.0
-        return self.__diagonal.blocks
-
-    def has_block(self, block):
-        warnings.warn("The has_block function is deprecated and "
-                      "will be removed in 0.16.0. "
-                      "Use `in matrix.axis_blocks` in the future.")
-        return self.block_spaces(block) is not None
-
-    def block_spaces(self, block):
-        warnings.warn("The block_spaces function is deprecated and "
-                      "will be removed in 0.16.0. "
-                      "Use `matrix.axis_spaces[block]` in the future.")
-        return {
-            "s": self.axis_spaces.get("ph", None),
-            "d": self.axis_spaces.get("pphh", None),
-            "t": self.axis_spaces.get("ppphhh", None),
-        }[block]
-
-    @property
     def axis_blocks(self):
         """
         Return the blocks used along one of the axes of the ADC matrix
@@ -278,26 +257,10 @@ class AdcMatrix(AdcMatrixlike):
         """
         return list(self.axis_spaces.keys())
 
-    def diagonal(self, block=None):
+    @property
+    def diagonal(self):
         """Return the diagonal of the ADC matrix"""
-        if block is not None:
-            warnings.warn("Support for the block argument will be dropped "
-                          "in 0.16.0.")
-            if block == "s":
-                return self.__diagonal.ph
-            if block == "d":
-                return self.__diagonal.pphh
         return self.__diagonal
-
-    def compute_apply(self, block, tensor):
-        warnings.warn("The compute_apply function is deprecated and "
-                      "will be removed in 0.16.0.")
-        if block in ("ss", "sd", "ds", "dd"):
-            warnings.warn("The singles-doubles interface is deprecated and "
-                          "will be removed in 0.16.0.")
-            block = {"ss": "ph_ph", "sd": "ph_pphh",
-                     "ds": "pphh_ph", "dd": "pphh_pphh"}[block]
-        return self.block_apply(block, tensor)
 
     def block_apply(self, block, tensor):
         """
@@ -311,7 +274,7 @@ class AdcMatrix(AdcMatrixlike):
         with self.timer.record(f"apply/{block}"):
             outblock, inblock = block.split("_")
             ampl = AmplitudeVector(**{inblock: tensor})
-            ret = self.blocks_ph[block](ampl)
+            ret = self.blocks[block](ampl)
             return getattr(ret, outblock)
 
     @timed_member_call()
@@ -320,20 +283,11 @@ class AdcMatrix(AdcMatrixlike):
         Compute the matrix-vector product of the ADC matrix
         with an excitation amplitude and return the result.
         """
-        return sum(block(v) for block in self.blocks_ph.values())
+        return sum(block(v) for block in self.blocks.values())
 
     def rmatvec(self, v):
         # ADC matrix is symmetric
         return self.matvec(v)
-
-    def compute_matvec(self, ampl):
-        """
-        Compute the matrix-vector product of the ADC matrix
-        with an excitation amplitude and return the result.
-        """
-        warnings.warn("The compute_matvec function is deprecated and "
-                      "will be removed in 0.16.0.")
-        return self.matvec(ampl)
 
     def __matmul__(self, other):
         if isinstance(other, AmplitudeVector):
@@ -563,25 +517,6 @@ class AdcMatrix(AdcMatrixlike):
 
             out[n_ph:, :n_ph] = np.transpose(out[:n_ph, n_ph:])
         return out
-
-
-class AdcBlockView(AdcMatrix):
-    def __init__(self, fullmatrix, block):
-        warnings.warn("The AdcBlockView class got deprecated and will be "
-                      "removed in 0.16.0. Use the matrix.block_view "
-                      "function instead.")
-        assert isinstance(fullmatrix, AdcMatrix)
-
-        self.__fullmatrix = fullmatrix
-        self.__block = block
-        if block == "s":
-            block_orders = dict(ph_ph=fullmatrix.block_orders["ph_ph"],
-                                ph_pphh=None, pphh_ph=None, pphh_pphh=None)
-        else:
-            raise NotImplementedError(f"Block {block} not implemented")
-        super().__init__(fullmatrix.method, fullmatrix.ground_state,
-                         block_orders=block_orders,
-                         intermediates=fullmatrix.intermediates)
 
 
 class AdcMatrixShifted(AdcMatrix):

--- a/adcc/AmplitudeVector.py
+++ b/adcc/AmplitudeVector.py
@@ -20,7 +20,6 @@
 ## along with adcc. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## ---------------------------------------------------------------------
-import warnings
 
 
 class AmplitudeVector(dict):

--- a/adcc/ExcitedStates.py
+++ b/adcc/ExcitedStates.py
@@ -540,29 +540,29 @@ class ExcitedStates(ElectronicTransition):
 
 
 # deprecated property names of ExcitedStates
-deprecated = {
-    "excitation_energies": "excitation_energy",
-    "transition_dipole_moments": "transition_dipole_moment",
-    "transition_dms": "transition_dm",
-    "transition_dipole_moments_velocity":
-        "transition_dipole_moment_velocity",
-    "transition_magnetic_dipole_moments":
-        "transition_magnetic_dipole_moment",
-    "state_dipole_moments": "state_dipole_moment",
-    "state_dms": "state_dm",
-    "state_diffdms": "state_diffdm",
-    "oscillator_strengths": "oscillator_strength",
-    "oscillator_stenths_velocity": "oscillator_strength_velocity",
-    "rotatory_strengths": "rotatory_strength",
-    "excitation_vectors": "excitation_vector",
-}
+# deprecated = {
+#     "excitation_energies": "excitation_energy",
+#     "transition_dipole_moments": "transition_dipole_moment",
+#     "transition_dms": "transition_dm",
+#     "transition_dipole_moments_velocity":
+#         "transition_dipole_moment_velocity",
+#     "transition_magnetic_dipole_moments":
+#         "transition_magnetic_dipole_moment",
+#     "state_dipole_moments": "state_dipole_moment",
+#     "state_dms": "state_dm",
+#     "state_diffdms": "state_diffdm",
+#     "oscillator_strengths": "oscillator_strength",
+#     "oscillator_stenths_velocity": "oscillator_strength_velocity",
+#     "rotatory_strengths": "rotatory_strength",
+#     "excitation_vectors": "excitation_vector",
+# }
 
-for dep_property in deprecated:
-    new_key = deprecated[dep_property]
+# for dep_property in deprecated:
+#     new_key = deprecated[dep_property]
 
-    def deprecated_property(self, key=new_key, old_key=dep_property):
-        warnings.warn(f"Property '{old_key}' is deprecated "
-                      " and will be removed in version 0.16.0."
-                      f" Please use '{key}' instead.")
-        return getattr(self, key)
-    setattr(ExcitedStates, dep_property, property(deprecated_property))
+#     def deprecated_property(self, key=new_key, old_key=dep_property):
+#         warnings.warn(f"Property '{old_key}' is deprecated "
+#                       " and will be removed in version 0.16.0."
+#                       f" Please use '{key}' instead.")
+#         return getattr(self, key)
+#     setattr(ExcitedStates, dep_property, property(deprecated_property))

--- a/adcc/ExcitedStates.py
+++ b/adcc/ExcitedStates.py
@@ -537,32 +537,3 @@ class ExcitedStates(ElectronicTransition):
         excitations = [Excitation(self, index=i, method=self.method)
                        for i in range(self.size)]
         return excitations
-
-
-# deprecated property names of ExcitedStates
-# deprecated = {
-#     "excitation_energies": "excitation_energy",
-#     "transition_dipole_moments": "transition_dipole_moment",
-#     "transition_dms": "transition_dm",
-#     "transition_dipole_moments_velocity":
-#         "transition_dipole_moment_velocity",
-#     "transition_magnetic_dipole_moments":
-#         "transition_magnetic_dipole_moment",
-#     "state_dipole_moments": "state_dipole_moment",
-#     "state_dms": "state_dm",
-#     "state_diffdms": "state_diffdm",
-#     "oscillator_strengths": "oscillator_strength",
-#     "oscillator_stenths_velocity": "oscillator_strength_velocity",
-#     "rotatory_strengths": "rotatory_strength",
-#     "excitation_vectors": "excitation_vector",
-# }
-
-# for dep_property in deprecated:
-#     new_key = deprecated[dep_property]
-
-#     def deprecated_property(self, key=new_key, old_key=dep_property):
-#         warnings.warn(f"Property '{old_key}' is deprecated "
-#                       " and will be removed in version 0.16.0."
-#                       f" Please use '{key}' instead.")
-#         return getattr(self, key)
-#     setattr(ExcitedStates, dep_property, property(deprecated_property))

--- a/adcc/IsrMatrix.py
+++ b/adcc/IsrMatrix.py
@@ -120,8 +120,7 @@ class IsrMatrix(AdcMatrixlike):
                                        variant=variant)
                 for block, order in self.block_orders.items() if order is not None
             } for op in self.operator]
-            # TODO Rename to self.block in 0.16.0
-            self.blocks_ph = [{
+            self.blocks = [{
                 b: bl[b].apply for b in bl
             } for bl in blocks]
 
@@ -136,7 +135,7 @@ class IsrMatrix(AdcMatrixlike):
         """
         ret = [
             sum(block(v) for block in bl_ph.values())
-            for bl_ph in self.blocks_ph
+            for bl_ph in self.blocks
         ]
         if len(ret) == 1:
             return ret[0]

--- a/adcc/OneParticleOperator.py
+++ b/adcc/OneParticleOperator.py
@@ -20,7 +20,6 @@
 ## along with adcc. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## ---------------------------------------------------------------------
-import warnings
 import numpy as np
 from itertools import product, combinations_with_replacement
 
@@ -156,15 +155,6 @@ class OneParticleOperator:
             self.__setitem__(b.__getattr__(attr), value)
         except AttributeError:
             super().__setattr__(attr, value)
-
-    def set_block(self, block, tensor):
-        """
-        Assigns tensor to a given block. Deprecated
-        """
-        warnings.warn("The set_block function is deprecated and will be "
-                      "removed in 0.16.0. "
-                      "Use __setitem__ instead.")
-        self.__setitem__(block, tensor)
 
     def set_zero_block(self, block):
         """

--- a/adcc/__init__.py
+++ b/adcc/__init__.py
@@ -28,7 +28,7 @@ from .LazyMp import LazyMp
 from .Tensor import Tensor
 from .Symmetry import Symmetry
 from .MoSpaces import MoSpaces
-from .AdcMatrix import AdcBlockView, AdcMatrix
+from .AdcMatrix import AdcMatrix
 from .AdcMethod import AdcMethod
 from .functions import (contract, copy, direct_sum, dot, einsum, empty_like,
                         evaluate, lincomb, linear_combination, nosym_like,

--- a/adcc/__init__.py
+++ b/adcc/__init__.py
@@ -50,7 +50,7 @@ from .guess import (guess_symmetries, guess_zero, guesses_any, guesses_singlet,
 from .workflow import run_adc
 from .exceptions import InputError
 
-__all__ = ["run_adc", "InputError", "AdcMatrix", "AdcBlockView",
+__all__ = ["run_adc", "InputError", "AdcMatrix",
            "AdcMethod", "Symmetry", "ReferenceState", "MoSpaces",
            "einsum", "contract", "copy", "dot", "empty_like", "evaluate",
            "lincomb", "nosym_like", "ones_like", "transpose",

--- a/adcc/__init__.py
+++ b/adcc/__init__.py
@@ -30,7 +30,7 @@ from .Symmetry import Symmetry
 from .MoSpaces import MoSpaces
 from .AdcMatrix import AdcMatrix
 from .AdcMethod import AdcMethod
-from .functions import (contract, copy, direct_sum, dot, einsum, empty_like,
+from .functions import (copy, direct_sum, dot, einsum, empty_like,
                         evaluate, lincomb, linear_combination, nosym_like,
                         ones_like, transpose, zeros_like)
 from .memory_pool import memory_pool
@@ -52,7 +52,7 @@ from .exceptions import InputError
 
 __all__ = ["run_adc", "InputError", "AdcMatrix",
            "AdcMethod", "Symmetry", "ReferenceState", "MoSpaces",
-           "einsum", "contract", "copy", "dot", "empty_like", "evaluate",
+           "einsum", "copy", "dot", "empty_like", "evaluate",
            "lincomb", "nosym_like", "ones_like", "transpose",
            "linear_combination", "zeros_like", "direct_sum",
            "memory_pool", "set_n_threads", "get_n_threads", "AmplitudeVector",

--- a/adcc/adc_pp/util.py
+++ b/adcc/adc_pp/util.py
@@ -33,14 +33,14 @@ def check_doubles_amplitudes(spaces, *amplitudes):
 
 
 def check_have_singles_block(*amplitudes):
-    if any("ph" not in amplitude.blocks_ph for amplitude in amplitudes):
+    if any("ph" not in amplitude.blocks for amplitude in amplitudes):
         raise ValueError("ADC(0) level and "
                          "beyond expects an excitation amplitude with a "
                          "singles part.")
 
 
 def check_have_doubles_block(*amplitudes):
-    if any("pphh" not in amplitude.blocks_ph for amplitude in amplitudes):
+    if any("pphh" not in amplitude.blocks for amplitude in amplitudes):
         raise ValueError("ADC(2) level and "
                          "beyond expects an excitation amplitude with a "
                          "singles and a doubles part.")

--- a/adcc/backends/test_backends_pcm.py
+++ b/adcc/backends/test_backends_pcm.py
@@ -49,7 +49,7 @@ class TestPCM(unittest.TestCase):
 
         # Consistency check with values obtained with ADCc
         assert_allclose(state.excitation_energy,
-                        result["ptlr_adcc_excitation_energy"], atol=1e-6)
+                        result["ptlr_adcc_excitation_energy"], atol=1e-5)
 
         if backend == "psi4":
             # remove cavity files from PSI4 PCM calculations

--- a/adcc/functions.py
+++ b/adcc/functions.py
@@ -120,7 +120,7 @@ def lincomb(coefficients, tensors, evaluate=False):
         return AmplitudeVector(**{
             block: lincomb(coefficients, [ten[block] for ten in tensors],
                            evaluate=evaluate)
-            for block in tensors[0].blocks_ph
+            for block in tensors[0].blocks
         })
     elif not isinstance(tensors[0], libadcc.Tensor):
         raise TypeError("Tensor type not supported")

--- a/adcc/functions.py
+++ b/adcc/functions.py
@@ -217,19 +217,3 @@ def einsum(subscripts, *operands, optimise="auto"):
     """
     return opt_einsum.contract(subscripts, *operands, optimize=optimise,
                                backend="libadcc")
-
-
-def contract(subscripts, a, b):
-    """
-    Form a single, einsum-like contraction, that is contract
-    tensor a and be to form out via a contraction defined
-    by the first argument string, e.g. "ab,bc->ac"
-    or "abc,bcd->ad".
-
-    Note: The contract function is deprecated. It will disappear in 0.16.
-    """
-    import warnings
-
-    warnings.warn(DeprecationWarning("contract is deprecated and will "
-                                     "be removed in 0.16. Use einsum."))
-    return einsum(subscripts, a, b)

--- a/adcc/solver/explicit_symmetrisation.py
+++ b/adcc/solver/explicit_symmetrisation.py
@@ -61,7 +61,7 @@ class IndexSymmetrisation():
             if not isinstance(vec, AmplitudeVector):
                 raise TypeError("new_vectors has to be an "
                                 "iterable of AmplitudeVector")
-            for b in vec.blocks_ph:
+            for b in vec.blocks:
                 if b not in self.symmetrisation_functions:
                     continue
                 vec[b] = evaluate(self.symmetrisation_functions[b](vec[b]))
@@ -88,7 +88,7 @@ class IndexSpinSymmetrisation(IndexSymmetrisation):
             # Only work on the doubles part
             # the other blocks are not yet implemented
             # or nothing needs to be done ("ph" block)
-            if "pphh" in vec.blocks_ph:
+            if "pphh" in vec.blocks:
                 # TODO: Note that the "d" is needed here because the C++ side
                 #       does not yet understand ph and pphh
                 amplitude_vector_enforce_spin_kind(

--- a/adcc/solver/test_power_method.py
+++ b/adcc/solver/test_power_method.py
@@ -37,6 +37,7 @@ sizes = ["0004", "0050", "0200", "1000"]
 @expand_test_templates(sizes)
 class TestPowerMethod(unittest.TestCase):
     def template_random_matrix(self, size):
+        np.random.seed(42)
         size = int(size)
         conv_tol = 1e-10
         ev = np.random.randn(size)

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -5,9 +5,9 @@ channels:
 dependencies:
   # Build
   - python
-  - gcc_linux-64 >=12
-  - gxx_linux-64 >=12
-  - libtensorlight =3.0.1=h3cb4726_2
+  - gcc_linux-64
+  - gxx_linux-64
+  - libtensorlight >=3.0.1
   - pybind11 >=2.6
   - pip
   # Run

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -66,26 +66,6 @@ The ``setup.py`` script of adcc is a largely a typical setuptools script,
 but has a few additional commands and features worth knowing:
 
 - ``setup.py build_ext``: Build the C++ part of adcc in the current directory.
-- ``setup.py test``: Run the adcc unit tests via
-  `pytest <https://docs.pytest.org>`_. Implies ``build_ext``.
-  This command has a few useful options:
-
-    - ``-m full``: Run the full test suite not only the fast tests
-    - ``-s``: Skip updating the testdata
-    - ``-a``: Pass additional arguments to ``pytest``
-      (`See pytest documentation <https://docs.pytest.org/en/latest/usage.html>`_).
-      This is extremely valuable in combination with the ``-k`` and ``-s`` flags
-      of ``pytest``.
-      For example
-
-      .. code-block:: shell
-
-         ./setup.py test -a "-k 'functionality and adc2'"
-
-      will run only the tests, which have the keywords "functionality" and
-      "adc2" in their description.
-- ``setup.py build_docs``: Build the documentation locally using
-  Doxygen and Sphinx. See the section below for details.
 - ``setup.py cpptests``: Build and run the C++ tests for ``libadcc``
 
 Documentation, documentation, documentation


### PR DESCRIPTION
As announced, this removes the old way of defining/accessing matrix/vector blocks (i.e. vec['s'] and so on).
Closes #181.