### PR TITLE
more flexible cached_member decorator

### DIFF
--- a/adcc/misc.py
+++ b/adcc/misc.py
@@ -22,6 +22,7 @@
 ## ---------------------------------------------------------------------
 import warnings
 import numpy as np
+import inspect
 from functools import wraps
 from pkg_resources import parse_version
 
@@ -58,8 +59,26 @@ def cached_member_function(function):
     """
     fname = function.__name__
 
+    # get the function signature and ensure that we don't have any
+    # keyword only arguments:
+    # func(..., *, kwarg=None, ...) or func(..., **kwargs).
+    # If we want to support them we need to add them in a well defined
+    # order to the cache key (sort them by name)
+    func_signature = inspect.signature(function)
+    bad_arg_types = (inspect.Parameter.KEYWORD_ONLY, inspect.Parameter.VAR_KEYWORD)
+    if any(arg.kind in bad_arg_types for arg in func_signature.parameters.values()):
+        raise ValueError("Member functions with keyword only arguments can not be "
+                         "wrapped with the cached_member_function.")
+
     @wraps(function)
-    def wrapper(self, *args):
+    def wrapper(self, *args, **kwargs):
+        # convert all arguments to poisitonal arguments and add default arguments
+        # for not provided arguments
+        bound_args = func_signature.bind(self, *args, **kwargs)
+        bound_args.apply_defaults()
+        assert not bound_args.kwargs
+        args = bound_args.args[1:]  # remove self from args
+
         try:
             fun_cache = self._function_cache[fname]
         except AttributeError:


### PR DESCRIPTION
There are 2 problems with the current version (see example below):
- It is not possible to call a decorated function with keyword arguments (quality of life)
- The decorator does not work with default arguments and might load unexpected results from the cache.

Neither of the points is currently a problem. Just to have it sorted for the future.

```
from adcc.misc import cached_member_function

class Test:
    @cached_member_function
    def foo(self, x, y = 1):
        print(x, y)

t = Test()

# this will not work
t.foo(x=2)

# this will print twice because the default argument
# is not correctly considered
t.foo(0)  # key for cache lookup: (0,)
t.foo(0, 1)  # key for cache lookup: (0, 1)
```