### PR TITLE
conv_tol crossref, remove PCM cavity files

### DIFF
--- a/adcc/backends/test_backends_crossref.py
+++ b/adcc/backends/test_backends_crossref.py
@@ -56,7 +56,7 @@ class TestCrossReferenceBackends(unittest.TestCase):
             scfres = cached_backend_hf(b, "r2methyloxirane", basis,
                                        conv_tol=1e-10)
             results[b] = adcc.adc2(scfres, n_singlets=3, conv_tol=1e-9)
-        compare_adc_results(results, 5e-8)
+        compare_adc_results(results, 5e-7)
 
     def template_adc2_uhf_ch2nh2(self, basis):
         results = {}

--- a/adcc/backends/test_backends_pcm.py
+++ b/adcc/backends/test_backends_pcm.py
@@ -173,7 +173,7 @@ class TestPCMcomparison(unittest.TestCase):
 def remove_cavity_psi4():
     # removes cavity files from PSI4 PCM calculations
     for cavityfile in os.listdir(os.getcwd()):
-        if cavityfile.startswith(("cavity.off_", "PEDRA.OUT_")):
+        if cavityfile.startswith(("cavity.", "PEDRA.OUT_")):
             os.remove(cavityfile)
 
 

--- a/adcc/backends/test_backends_pcm.py
+++ b/adcc/backends/test_backends_pcm.py
@@ -173,7 +173,7 @@ class TestPCMcomparison(unittest.TestCase):
 def remove_cavity_psi4():
     # removes cavity files from PSI4 PCM calculations
     for cavityfile in os.listdir(os.getcwd()):
-        if cavityfile.startswith(("cavity.", "PEDRA.OUT_")):
+        if cavityfile.startswith(("cavity.off_", "cavity.npz", "PEDRA.OUT_")):
             os.remove(cavityfile)
 
 


### PR DESCRIPTION
**Changes**

- `adcc/backends/test_backends_crossref.py`: 
  As mentioned in Issue #186, test_adc2_r2methyloxirane_ccpvdz used to fail, I increased the convergence criteria to 5e-7, as discussed with @jonasleitner, and now the test passes again. 

- `adcc/backends/test_backends_pcm.py`:
 The `cavity.npz` file from the `Psi4` calculation was not removed after the tests. I added it to the files which are removed after the tests in `remove_cavity_psi4`.