### PR TITLE
Fix orthgonality loss in Davidson using Gram-Schmidt reorthogonalisation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,7 +89,7 @@ jobs:
         if: matrix.documentation
       #
       - name: Upload coverage to codecov
-        # Note: lcov curerntly produces some error and therefore requires the keep-going flag to complete.
+        # Note: lcov currently produces some error and therefore requires the keep-going flag to complete.
         # Since the error might be the result of some gcc/gcov bug, I don't know how to resolve it currently.
         # lcov < 2.0 apparently did hide a lot of errors from the user so the problem might have been around for some time already...
         run: |
@@ -99,6 +99,8 @@ jobs:
           lcov --ignore-errors unused --remove coverage.info '/opt/*' '/Applications/*' '/Library/*' '/usr/*' "${HOME}"'/.cache/*' "${HOME}"'/.local/*' "${PWD}"'/build/*' "${PWD}"'/libadcc/tests/*' --output-file coverage.info
           lcov --list coverage.info
           codecov -X gcov -f coverage.info
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         if: contains(matrix.os, 'ubuntu')
 
       - name: Upload coverage to coveralls

--- a/adcc/solver/SolverStateBase.py
+++ b/adcc/solver/SolverStateBase.py
@@ -39,6 +39,7 @@ class EigenSolverStateBase:
         self.converged = False            # Flag whether iteration is converged
         self.n_iter = 0                   # Number of iterations
         self.n_applies = 0                # Number of applies
+        self.reortho_triggers = []        # List of reorthogonalisation triggers
         self.timer = Timer()              # Construct a new timer
 
     def describe(self):
@@ -56,6 +57,10 @@ class EigenSolverStateBase:
         text += "| {0:<41s}  {1:>15s} |\n".format(algorithm, conv)
         text += ("| {0:30s} n_iter={1:<3d}  n_applies={2:<5d} |\n"
                  "".format(problem[:30], self.n_iter, self.n_applies))
+        text += ("| n_reortho={0:<7d}  max_overlap_before_reortho={1:<10s}   |\n"
+                 "".format(len(self.reortho_triggers),
+                           "{:<10.4E}".format(max(self.reortho_triggers))
+                           if len(self.reortho_triggers) > 0 else "N/A"))
         text += "+" + 60 * "-" + "+\n"
         text += ("|  #     eigenvalue  res. norm       "
                  "dominant elements       |\n")

--- a/adcc/solver/davidson.py
+++ b/adcc/solver/davidson.py
@@ -163,8 +163,7 @@ def davidson_iterations(matrix, state, max_subspace, max_iter, n_ep, n_block,
     # Get the worksize view for the first iteration
     Ass = Ass_cont[:n_ss_vec, :n_ss_vec]
 
-    # Initiall projection of Ax onto the subspace, exploiting the hermiticity
-    # of the Ass matrix
+    # Initiall projection of Ax onto the subspace exploiting the hermiticity
     with state.timer.record("projection"):
         for i in range(n_ss_vec):
             for j in range(i, n_ss_vec):
@@ -410,7 +409,7 @@ def eigsh(matrix, guesses, n_ep=None, n_block=None, max_subspace=None,
         n_ep = len(guesses)
     elif n_ep > len(guesses):
         raise ValueError(f"n_ep (= {n_ep}) cannot exceed the number of guess "
-                         f"vectors {len(guesses)}.")
+                         f"vectors (= {len(guesses)}).")
 
     if n_block is None:
         n_block = n_ep

--- a/adcc/solver/davidson.py
+++ b/adcc/solver/davidson.py
@@ -94,7 +94,8 @@ def davidson_iterations(matrix, state, max_subspace, max_iter, n_ep, n_block,
     n_ep : int or NoneType, optional
         Number of eigenpairs to be computed
     n_block : int or NoneType, optional
-        Davidson block size
+        Davidson block size: the number of vectors that are added to the subspace
+        in each iteration
     is_converged
         Function to test for convergence
     callback : callable, optional
@@ -144,7 +145,7 @@ def davidson_iterations(matrix, state, max_subspace, max_iter, n_ep, n_block,
         raise ValueError("n_block cannot exceed the number of guess vectors.")
     elif n_block < n_ep:
         raise ValueError("n_block cannot be smaller than the number of "
-            "states requested.")
+                         "states requested.")
 
     # The current subspace
     SS = state.subspace_vectors

--- a/adcc/tests/backends/backends_crossref_test.py
+++ b/adcc/tests/backends/backends_crossref_test.py
@@ -65,10 +65,14 @@ class TestCrossReferenceBackends:
             pytest.skip("Veloxchem does not support f-functions. "
                         "Not enough backends available.")
 
-        # fewer states available for fc-fv-cvs
-        n_states = 5
-        if "fc" in case and "fv" in case and "cvs" in case:
-            n_states = 4
+        kwargs = {"n_singlets": 5}
+        # fewer states available for fc-fv-cvs (4) and fv-cvs (5)
+        if "fv" in case and "cvs" in case:
+            kwargs["n_singlets"] = 3
+            kwargs["n_guesses"] = 3
+        elif "cvs" in case:
+            # state 5 and 6 are degenerate -> can't compare the eigenvectors
+            kwargs["n_singlets"] = 4
 
         method = "cvs-adc2" if "cvs" in case else "adc2"
         core_orbitals = system.core_orbitals if "cvs" in case else None
@@ -79,9 +83,9 @@ class TestCrossReferenceBackends:
         for b in backends_test:
             scfres = cached_backend_hf(b, system, conv_tol=1e-10)
             results[b] = adcc.run_adc(
-                scfres, method=method, n_singlets=n_states, conv_tol=1e-9,
+                scfres, method=method, conv_tol=1e-9,
                 core_orbitals=core_orbitals, frozen_core=frozen_core,
-                frozen_virtual=frozen_virtual
+                frozen_virtual=frozen_virtual, **kwargs
             )
             assert results[b].converged
         compare_adc_results(results, 5e-8)

--- a/adcc/tests/functionality_test.py
+++ b/adcc/tests/functionality_test.py
@@ -133,12 +133,16 @@ class TestFunctionality:
         n_states = testcases.kinds_to_nstates([kind]).pop()
 
         kwargs = {n_states: 3}
-        # only few states available for h2o sto3g adc0/adc1
-        if system.name == "h2o" and system.basis == "sto-3g" and method.level < 2:
-            if "cvs" in case and "fv" in case:
-                kwargs[n_states] = 1
-            elif "cvs" in case:
-                kwargs[n_states] = 2
+        # only few states available for h2o sto3g
+        if system.name == "h2o" and system.basis == "sto-3g":
+            if method.level < 2:  # adc0/adc1
+                if "cvs" in case and "fv" in case:
+                    kwargs[n_states] = 1
+                elif "cvs" in case:
+                    kwargs[n_states] = 2
+            elif method.level < 4:  # adc2/adc3
+                if "cvs" in case and "fv" in case:  # only 5 states available
+                    kwargs["n_guesses"] = 3
 
         self.base_test(
             system=system, case=case, method=method.name, kind=kind,

--- a/adcc/tests/solver/davidson_test.py
+++ b/adcc/tests/solver/davidson_test.py
@@ -43,21 +43,23 @@ class TestSolverDavidson(unittest.TestCase):
         guesses = adcc.guesses_singlet(self.matrix, n_guesses=1, block="ph")
         with pytest.raises(ValueError):
             eigsh(self.matrix, guesses, n_ep=2)
-        res = eigsh(self.matrix, guesses, n_ep=1)
+        res = eigsh(self.matrix, guesses, n_ep=1, max_iter=1)
         assert len(res.eigenvalues) == 1
-        # construct 1 state for each guess
-        res = eigsh(self.matrix, guesses)
+        # by default: construct 1 state for each guess
+        res = eigsh(self.matrix, guesses, max_iter=1)
         assert len(res.eigenvalues) == 1
 
     def test_n_block(self):
         # has to be: n_ep <= n_block <= n_guesses
-        guesses = adcc.guesses_singlet(self.matrix, n_guesses=2, block="ph")
+        guesses = adcc.guesses_singlet(self.matrix, n_guesses=3, block="ph")
         with pytest.raises(ValueError):
             eigsh(self.matrix, guesses, n_ep=2, n_block=1)
         with pytest.raises(ValueError):
-            eigsh(self.matrix, guesses, n_ep=2, n_block=3)
-        res = eigsh(self.matrix, guesses, n_ep=2, n_block=2)
+            eigsh(self.matrix, guesses, n_ep=2, n_block=4)
+        # defaults to n_ep
+        res = eigsh(self.matrix, guesses, n_ep=2, max_iter=2)
         assert len(res.eigenvalues) == 2
+        assert res.n_applies == 5
 
     def test_max_subspace(self):
         # max_subspace >= 2 * n_block

--- a/adcc/tests/solver/davidson_test.py
+++ b/adcc/tests/solver/davidson_test.py
@@ -25,24 +25,85 @@ import unittest
 import pytest
 
 from adcc import LazyMp
-from adcc.solver.davidson import jacobi_davidson
+from adcc.solver.davidson import jacobi_davidson, eigsh
+from adcc.misc import cached_property
 
 from ..testdata_cache import testdata_cache
 
 
 class TestSolverDavidson(unittest.TestCase):
+    @cached_property
+    def matrix(self):
+        return adcc.AdcMatrix(
+            "adc2", LazyMp(testdata_cache.refstate("h2o_sto3g", case="gen"))
+        )
+
+    def test_n_guesses(self):
+        # we have to have a guess for each state
+        guesses = adcc.guesses_singlet(self.matrix, n_guesses=1, block="ph")
+        with pytest.raises(ValueError):
+            eigsh(self.matrix, guesses, n_ep=2)
+        res = eigsh(self.matrix, guesses, n_ep=1)
+        assert len(res.eigenvalues) == 1
+        # construct 1 state for each guess
+        res = eigsh(self.matrix, guesses)
+        assert len(res.eigenvalues) == 1
+
+    def test_n_block(self):
+        # has to be: n_ep <= n_block <= n_guesses
+        guesses = adcc.guesses_singlet(self.matrix, n_guesses=2, block="ph")
+        with pytest.raises(ValueError):
+            eigsh(self.matrix, guesses, n_ep=2, n_block=1)
+        with pytest.raises(ValueError):
+            eigsh(self.matrix, guesses, n_ep=2, n_block=3)
+        res = eigsh(self.matrix, guesses, n_ep=2, n_block=2)
+        assert len(res.eigenvalues) == 2
+
+    def test_max_subspace(self):
+        # max_subspace >= 2 * n_block
+        guesses = adcc.guesses_singlet(self.matrix, n_guesses=3, block="ph")
+        with pytest.raises(ValueError):
+            eigsh(self.matrix, guesses, n_ep=1, n_block=2, max_subspace=3)
+        res = eigsh(self.matrix, guesses, n_ep=1, n_block=2, max_subspace=4)
+        assert len(res.eigenvalues) == 1
+        # max_subspace >= n_guesses
+        with pytest.raises(ValueError):
+            eigsh(self.matrix, guesses, n_ep=1, n_block=1, max_subspace=2)
+        res = eigsh(self.matrix, guesses, n_ep=1, n_block=1, max_subspace=3)
+        assert len(res.eigenvalues) == 1
+
+    def test_adc0_singlet(self):
+        # ensure that a diagonal matrix (with guesses from the diagonal)
+        # converges in a single iteration to the correct eigenvalues
+        refdata = testdata_cache.adcman_data(
+            system="h2o_sto3g", method="adc0", case="gen"
+        )["singlet"]
+
+        matrix = adcc.AdcMatrix(
+            "adc0", LazyMp(testdata_cache.refstate("h2o_sto3g", case="gen"))
+        )
+
+        # Solve for singlets
+        guesses = adcc.guesses_singlet(matrix, n_guesses=2, block="ph")
+        res = jacobi_davidson(matrix, guesses, n_ep=2)
+
+        assert res.converged
+        assert res.n_iter == 1
+        assert res.n_applies == 2
+
+        ref_singlets = refdata["eigenvalues"]
+        n_states = min(len(ref_singlets), len(res.eigenvalues))
+        assert n_states > 1
+        assert res.eigenvalues[:n_states] == pytest.approx(ref_singlets[:n_states])
+
     def test_adc2_singlets(self):
         refdata = testdata_cache.adcman_data(
             system="h2o_sto3g", method="adc2", case="gen"
         )["singlet"]
 
-        matrix = adcc.AdcMatrix(
-            "adc2", LazyMp(testdata_cache.refstate("h2o_sto3g", case="gen"))
-        )
-
         # Solve for singlets
-        guesses = adcc.guesses_singlet(matrix, n_guesses=9, block="ph")
-        res = jacobi_davidson(matrix, guesses, n_ep=9)
+        guesses = adcc.guesses_singlet(self.matrix, n_guesses=9, block="ph")
+        res = jacobi_davidson(self.matrix, guesses, n_ep=9)
 
         ref_singlets = refdata["eigenvalues"]
         n_states = min(len(ref_singlets), len(res.eigenvalues))
@@ -54,13 +115,10 @@ class TestSolverDavidson(unittest.TestCase):
         refdata = testdata_cache.adcman_data(
             system="h2o_sto3g", method="adc2", case="gen"
         )["triplet"]
-        matrix = adcc.AdcMatrix(
-            "adc2", LazyMp(testdata_cache.refstate("h2o_sto3g", case="gen"))
-        )
 
         # Solve for triplets
-        guesses = adcc.guesses_triplet(matrix, n_guesses=10, block="ph")
-        res = jacobi_davidson(matrix, guesses, n_ep=10)
+        guesses = adcc.guesses_triplet(self.matrix, n_guesses=10, block="ph")
+        res = jacobi_davidson(self.matrix, guesses, n_ep=10)
 
         ref_triplets = refdata["eigenvalues"]
         n_states = min(len(ref_triplets), len(res.eigenvalues))

--- a/adcc/workflow.py
+++ b/adcc/workflow.py
@@ -391,7 +391,13 @@ def diagonalise_adcmatrix(matrix, n_states, kind, eigensolver="davidson",
     # Obtain or check guesses
     if guesses is None:
         if n_guesses is None:
-            n_guesses = estimate_n_guesses(matrix, n_states, n_guesses_per_state)
+            # restrict to the number of available singles guesses for if no doubles
+            # are available
+            n_guesses = estimate_n_guesses(
+                matrix=matrix, n_states=n_states,
+                singles_only=("pphh" not in matrix.axis_blocks),
+                n_guesses_per_state=n_guesses_per_state
+            )
         guesses = obtain_guesses_by_inspection(matrix, n_guesses, kind,
                                                n_guesses_doubles)
     else:

--- a/adcc/workflow.py
+++ b/adcc/workflow.py
@@ -391,7 +391,7 @@ def diagonalise_adcmatrix(matrix, n_states, kind, eigensolver="davidson",
     # Obtain or check guesses
     if guesses is None:
         if n_guesses is None:
-            # restrict to the number of available singles guesses for if no doubles
+            # restrict to the number of available singles guesses if no doubles
             # are available
             n_guesses = estimate_n_guesses(
                 matrix=matrix, n_states=n_states,


### PR DESCRIPTION
This pull request covers several issues related to the Davidson solver:

- The Davidson solver occasionally lost subspace orthogonality, sometimes leading to linear dependence within the subspace, resulting in instant solver convergence towards zero eigenpairs.
With this pull request, subspace orhogonality loss is fixed using a conventional Gram-Schmidt reorthogonalisation in case this is needed, i.e., whenever the vector to be added to the subspace has non-negligible overlap with the previous subspace vectors. This comes at the expense of, at least, computing `n_ss_vec` addtional scalar products in each step, which in small systems may amount up to 5% of the total computational time spent for the Davidson solver. The overhead scales $N^4$, that is, for larger systems, the relative penalty can be expected to be negligible.

- In the Davidson solver setup, it was not differentiated between the initial subspace size, that is, the number of guesses provided, and the Davidson block size `n_block`. In cases where the number of roots to be converged is considerably smaller than the number of guesses, large `n_block` values lead to a considerable overhead in computational costs compared to a conventional strategy in which the Davidson block size is set to be equal to the number of roots to be converged.
With this pull request, the default is changed such that the Davidson block size is set to be equal to the number of roots to be converged.

In addition, some minor unrelated issues are fixed:

- A bug in the call of `workflow.py`'s `estimate_n_guesses` function could prevent the generation of doubles guesses in some edge cases
- The CI workflow was adjusted to use a token for code coverage analysis uploads to codecov.org