### PR TITLE
Full 2p-ISR(2) difference density

### DIFF
--- a/adcc/AdcMatrix.py
+++ b/adcc/AdcMatrix.py
@@ -28,7 +28,7 @@ import libadcc
 from .LazyMp import LazyMp
 from .adc_pp import matrix as ppmatrix
 from .timings import Timer, timed_member_call
-from .AdcMethod import AdcMethod, IsrMethod, Method
+from .AdcMethod import AdcMethod, Method
 from .functions import ones_like
 from .Intermediates import Intermediates
 from .AmplitudeVector import AmplitudeVector
@@ -74,12 +74,24 @@ class AdcMatrixlike:
     _special_block_orders = {
         "adc2x": {"ph_ph": 2, "ph_pphh": 1, "pphh_ph": 1, "pphh_pphh": 1},
         "isr1s": {"ph_ph": 1, "ph_pphh": None, "pphh_ph": None, "pphh_pphh": None},
+        "isr2d": {"ph_ph": 2, "ph_pphh": 1, "pphh_ph": 1, "pphh_pphh": 0},
     }
 
     @classmethod
-    def _default_block_orders(cls, method: Method) -> dict[str, int]:
+    def _default_block_orders(cls, method: Method,
+                              n_zeroth_order_off_diag_couplings: int
+                              ) -> dict[str, int]:
         """
         Determines the default block orders for the given adc method.
+
+        Parameters
+        ----------
+        method: Method
+            The method to generate default block orders for.
+        n_zeroth_order_off_diag_couplings: int
+            The number of coupling blocks in the ADC/ISR matrix with
+            non-vanishing zeroth-order contributions, e.g.,
+            0 for the secular matrix and 1 for the 1-particle ISR matrix.
         """
         # check if we have a special method like adc2x
         # I guess base_method should also contain the adc_type prefix so
@@ -99,23 +111,12 @@ class AdcMatrixlike:
             raise ValueError(f"Unknown adc type {method.adc_type} for method "
                              f"{method.name}. Can not determine default block "
                              "orders.")
-        # ADC matrices have first-order coupling whereas ISR matrices
-        # have a zeroth-order coupling between adjacent excitation classes
-        # see https://doi.org/10.1063/1.1752875
-        if isinstance(method, AdcMethod):
-            # First-order coupling between adjacent excitation classes.
-            spaces = [
-                "p" * i + min_space + "h" * i
-                for i in range(0, (method.level.to_int() // 2) + 1)
-            ]
-        elif isinstance(method, IsrMethod):
-            # Zeroth-order coupling between adjacent excitation classes.
-            spaces = [
-                "p" * i + min_space + "h" * i
-                for i in range(0, ((method.level.to_int() + 1) // 2) + 1)
-            ]
-        else:
-            raise ValueError(f"Invalid method: {method.name}")
+        n_spaces = (
+            ((method.level.to_int() + n_zeroth_order_off_diag_couplings) // 2) + 1
+        )
+        spaces = [
+            "p" * i + min_space + "h" * i for i in range(0, n_spaces)
+        ]
         # exploit the fact that the spaces are sorted from small to high:
         # If we walk the adc matrix in any direction we always have to subtract 1!
         # Therefore, we can determine the order according to the position of the
@@ -254,7 +255,9 @@ class AdcMatrix(AdcMatrixlike):
         if self.intermediates is None:
             self.intermediates = Intermediates(self.ground_state)
 
-        self.block_orders = self._default_block_orders(self.method)
+        self.block_orders = self._default_block_orders(
+            self.method, n_zeroth_order_off_diag_couplings=0
+        )
         if block_orders is not None:
             self.block_orders.update(block_orders)
         self._validate_block_orders(

--- a/adcc/AdcMatrix.py
+++ b/adcc/AdcMatrix.py
@@ -28,7 +28,7 @@ import libadcc
 from .LazyMp import LazyMp
 from .adc_pp import matrix as ppmatrix
 from .timings import Timer, timed_member_call
-from .AdcMethod import AdcMethod, Method
+from .AdcMethod import AdcMethod, Method, AdcType
 from .functions import ones_like
 from .Intermediates import Intermediates
 from .AmplitudeVector import AmplitudeVector
@@ -104,12 +104,12 @@ class AdcMatrixlike:
         # - determine which spaces are available in the ADC(n) matrix
         #   starting from the given minimal space
         min_space = {
-            "pp": "ph"
+            AdcType.PP: "ph"
         }.get(method.adc_type, None)
         if min_space is None:
-            raise ValueError(f"Unknown adc type {method.adc_type} for method "
-                             f"{method.name}. Can not determine default block "
-                             "orders.")
+            raise ValueError(f"Unknown adc type {method.adc_type.to_str()} for "
+                             f"method {method.name}. Can not determine default "
+                             "block orders.")
         assert bandwidth >= 0
         n_spaces = ((method.level.to_int() + bandwidth) // 2) + 1
         spaces = [
@@ -160,7 +160,7 @@ class AdcMatrixlike:
             if not cls._is_valid_space(bra, method) or \
                     not cls._is_valid_space(ket, method):
                 raise ValueError(f"Invalid block {block} for a "
-                                 f"{method.adc_type} ADC matrix.")
+                                 f"{method.adc_type.to_str()} ADC matrix.")
             if bra == ket:  # done for diagonal blocks
                 continue
             # ensure that the matrix is symmetric
@@ -194,9 +194,9 @@ class AdcMatrixlike:
             return False
         # depending on the adc type n_particle and n_hole have to
         # be equal or differ e.g. by +-1 (IP/EA)
-        if method.adc_type == "pp":
+        if method.adc_type is AdcType.PP:
             return n_particle == n_hole
-        raise ValueError(f"Unknown adc type {method.adc_type} for method "
+        raise ValueError(f"Unknown adc type {method.adc_type.to_str()} for method "
                          f"{method.name}. Can not validate space.")
 
 

--- a/adcc/AdcMatrix.py
+++ b/adcc/AdcMatrix.py
@@ -79,8 +79,7 @@ class AdcMatrixlike:
 
     @classmethod
     def _default_block_orders(cls, method: Method,
-                              n_zeroth_order_off_diag_couplings: int
-                              ) -> dict[str, int]:
+                              bandwidth: int) -> dict[str, int]:
         """
         Determines the default block orders for the given adc method.
 
@@ -111,8 +110,9 @@ class AdcMatrixlike:
             raise ValueError(f"Unknown adc type {method.adc_type} for method "
                              f"{method.name}. Can not determine default block "
                              "orders.")
+        assert bandwidth >= 0
         n_spaces = (
-            ((method.level.to_int() + n_zeroth_order_off_diag_couplings) // 2) + 1
+            ((method.level.to_int() + bandwidth) // 2) + 1
         )
         spaces = [
             "p" * i + min_space + "h" * i for i in range(0, n_spaces)
@@ -256,7 +256,7 @@ class AdcMatrix(AdcMatrixlike):
             self.intermediates = Intermediates(self.ground_state)
 
         self.block_orders = self._default_block_orders(
-            self.method, n_zeroth_order_off_diag_couplings=0
+            self.method, bandwidth=0
         )
         if block_orders is not None:
             self.block_orders.update(block_orders)

--- a/adcc/AdcMatrix.py
+++ b/adcc/AdcMatrix.py
@@ -87,7 +87,7 @@ class AdcMatrixlike:
         ----------
         method: Method
             The method to generate default block orders for.
-        n_zeroth_order_off_diag_couplings: int
+        bandwidth: int
             The number of coupling blocks in the ADC/ISR matrix with
             non-vanishing zeroth-order contributions, e.g.,
             0 for the secular matrix and 1 for the 1-particle ISR matrix.
@@ -111,9 +111,7 @@ class AdcMatrixlike:
                              f"{method.name}. Can not determine default block "
                              "orders.")
         assert bandwidth >= 0
-        n_spaces = (
-            ((method.level.to_int() + bandwidth) // 2) + 1
-        )
+        n_spaces = ((method.level.to_int() + bandwidth) // 2) + 1
         spaces = [
             "p" * i + min_space + "h" * i for i in range(0, n_spaces)
         ]

--- a/adcc/AdcMethod.py
+++ b/adcc/AdcMethod.py
@@ -37,8 +37,15 @@ class MethodLevel(Enum):
 
     # special levels
     TWO_X = "2x"    # extended 2nd-order ADC: 2p2h-2p2h in 1st order
-    ONE_S = "1s"    # 1st-order ISR: in singles excitation space only
-    THREE_D = "3d"  # 3rd-order ISR: in singles/doubles excitation space only
+    # 1st-order ISR: in singles excitation space only (starting from 1-particle
+    # operators, doubles are required for a consistent first-order description)
+    ONE_S = "1s"
+    # 2nd-order ISR: in doubles excitation space only (starting from 2-particle
+    # operators, triples are required for a consistent second-order description)
+    TWO_D = "2d"
+    # 3nd-order ISR: in doubles excitation space only (starting from 1-particle
+    # operators, triples are required for a consistent third-order description)
+    THREE_D = "3d"
 
     def to_str(self) -> str:
         return str(self.value)
@@ -163,4 +170,4 @@ class AdcMethod(Method):
 class IsrMethod(Method):
     _method_base_name = "isr"
     max_level = 2
-    special_levels = (MethodLevel.ONE_S,)
+    special_levels = (MethodLevel.ONE_S, MethodLevel.TWO_D)

--- a/adcc/AdcMethod.py
+++ b/adcc/AdcMethod.py
@@ -20,7 +20,7 @@
 ## along with adcc. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## ---------------------------------------------------------------------
-from typing import Optional, TypeVar
+from typing import Optional, Union, TypeVar
 from enum import Enum
 
 T = TypeVar("T", bound="Method")
@@ -43,7 +43,7 @@ class MethodLevel(Enum):
     # 2nd-order ISR: in doubles excitation space only (starting from 2-particle
     # operators, triples are required for a consistent second-order description)
     TWO_D = "2d"
-    # 3nd-order ISR: in doubles excitation space only (starting from 1-particle
+    # 3rd-order ISR: in doubles excitation space only (starting from 1-particle
     # operators, triples are required for a consistent third-order description)
     THREE_D = "3d"
 
@@ -111,8 +111,8 @@ class Method:
     @property
     def name(self) -> str:
         """The name of the Method as string."""
-        if self.is_core_valence_separated:
-            return "cvs-" + self._base_method
+        if self.prefixes:
+            return f"{self.prefixes}-{self._base_method}"
         else:
             return self._base_method
 
@@ -122,6 +122,14 @@ class Method:
         return self._method_base_name + self.level.to_str()
 
     @property
+    def prefixes(self) -> str:
+        """String containing all prefixes of the method separated by '-'."""
+        ret = []
+        if self.is_core_valence_separated:
+            ret.append("cvs")
+        return "-".join(ret)
+
+    @property
     def base_method(self: T) -> T:
         """
         The base (full) method, i.e. with all approximations such as
@@ -129,16 +137,20 @@ class Method:
         """
         return self.__class__(self._base_method)
 
-    def at_level(self: T, newlevel: int) -> T:
+    def at_level(self: T, newlevel: Union[int, str]) -> T:
         """
         Return an equivalent method, where only the level is changed
         (e.g. calling this on a CVS method returns a CVS method)
         """
         assert self._method_base_name is not None
-        if self.is_core_valence_separated:
-            return self.__class__("cvs-" + self._method_base_name + str(newlevel))
+        if self.prefixes:
+            return self.__class__(
+                f"{self.prefixes}-{self._method_base_name}{newlevel}"
+            )
         else:
-            return self.__class__(self._method_base_name + str(newlevel))
+            return self.__class__(
+                f"{self._method_base_name}{newlevel}"
+            )
 
     def as_method(self, method_cls: type[T]) -> T:
         """

--- a/adcc/AdcMethod.py
+++ b/adcc/AdcMethod.py
@@ -53,6 +53,10 @@ class MethodLevel(Enum):
         return str(self.value)
 
     def to_int(self) -> int:
+        """
+        Converts the level to an integer. This also resolves special
+        levels. For instance, 'TWO_X' resolves as 2.
+        """
         # numerical methods
         if isinstance(self.value, int):
             return self.value
@@ -60,7 +64,7 @@ class MethodLevel(Enum):
         elif isinstance(self.value, str):
             return int(self.value[0])
         else:
-            raise ValueError
+            raise ValueError(f"Unknown value type {type(self.value)}.")
 
 
 class Method:

--- a/adcc/AdcMethod.py
+++ b/adcc/AdcMethod.py
@@ -73,12 +73,28 @@ class AdcType(Enum):
     def to_str(self) -> str:
         return self.value
 
+    @classmethod
+    def is_valid_adc_type(cls, adc_type: str) -> bool:
+        try:
+            cls(adc_type)
+            return True
+        except ValueError:
+            return False
+
 
 class GroundStateType(Enum):
     MP = "mp"
 
     def to_str(self) -> str:
         return self.value
+
+    @classmethod
+    def is_valid_gs_type(cls, gs_type: str) -> bool:
+        try:
+            cls(gs_type)
+            return True
+        except ValueError:
+            return False
 
 
 class Method:
@@ -88,9 +104,16 @@ class Method:
     special_levels: tuple[MethodLevel, ...] = tuple()
 
     def __init__(self, method: str):
+        """
+        Constructs a Method validating and decomposing the given method string.
+        Valid method strings are of the form
+        [prefixes]-[adc_type]-[method_base_name][level]
+        with the individual components separated by '-'.
+        """
         assert self._method_base_name is not None
 
-        # validate base method type
+        # validate base method type, which has to be the last part of the
+        # method string
         split = method.split("-")
         if not split[-1].startswith(self._method_base_name):
             raise ValueError(f"{split[-1]} is not a valid method type")
@@ -103,39 +126,50 @@ class Method:
             self.level: MethodLevel = MethodLevel(level)
 
         split = split[:-1]
-        # validate and set the adc_type
-        try:
+        # validate and set the adc_type, which has to be the last entry of split,
+        # i.e., the method string has to end with e.g. ip-adc2
+        self.adc_type: AdcType = AdcType.PP
+        if split and AdcType.is_valid_adc_type(split[-1]):
             self.adc_type: AdcType = AdcType(split[-1])
             split = split[:-1]
-        except (ValueError, IndexError):
-            self.adc_type: AdcType = AdcType("pp")
-
-        self._validate_level(self.level)
+        # Therefore, all remaining prefixes at this point can not be
+        # a valid adc_type
+        if any(AdcType.is_valid_adc_type(pref) for pref in split):
+            raise ValueError(
+                f"Invalid method string {method}. ADC type (e.g. 'pp') either "
+                "provided twice or in wrong position. Valid method strings "
+                f"have to end with e.g. 'pp-adc2'."
+            )
         # validate prefixes
         valid_prefixes: tuple[str, ...] = ("cvs", "mp")
-        if len(split) > len(valid_prefixes):
-            raise ValueError("Invalid number of method prefixes provided "
-                             f"in {split}.")
         if any(pref not in valid_prefixes for pref in split):
-            raise ValueError(f"Invalid method prefix in {split}.")
+            raise ValueError(f"Invalid method prefix in {split}. Valid prefixes "
+                             f"are {valid_prefixes}.")
         if any(count != 1 for count in Counter(split).values()):
             raise ValueError(f"Invalid method string {method}. Duplicate "
                              f"prefix detected in {split}.")
         # set and remove cvs
         self.is_core_valence_separated: bool = "cvs" in split
-        if "cvs" in split:
+        if self.is_core_valence_separated:
             split.remove("cvs")
-        # finally set and validate gs type (the only allowed prefix left
-        # at this point)
+        # deal with the gs_type
+        self.gs_type: GroundStateType = GroundStateType.MP
+        for pref in split:
+            if GroundStateType.is_valid_gs_type(pref):
+                self.gs_type: GroundStateType = GroundStateType(pref)
+                split.remove(pref)
+                break
+        # The remaining prefixes can not be a ground state type anymore
+        if any(GroundStateType.is_valid_gs_type(pref) for pref in split):
+            raise ValueError(f"Invalid method string {method}. Ground state "
+                             "type (e.g. 'mp') provided twice.")
+        # at this point all prefixes should have been handled and removed
         if split:
-            self.gs_type: GroundStateType = GroundStateType(split[0])
-            split.pop(0)
-        else:
-            self.gs_type: GroundStateType = GroundStateType("mp")
-        # at this point all prefixes should have been handled
-        if split:
-            raise ValueError(f"Invalid prefix in {split} detected."
-                             f"Parsed from method string {method}.")
+            raise ValueError(f"Invalid method prefixes detected: {split}."
+                             f"Parsed from method string '{method}'.")
+        # ensure that the level is valid for the given method
+        # this also depends on the adc type, gs_type and possibly other prefixes
+        self._validate_level(self.level)
 
     def _validate_level(self, level: MethodLevel) -> None:
         if isinstance(level.value, int) and level.value <= self.max_level:
@@ -145,7 +179,7 @@ class Method:
         if level in self.special_levels:
             return
 
-        raise NotImplementedError(f"{self._base_method} is not implemented.")
+        raise NotImplementedError(f"{self.name} method is not implemented.")
 
     @property
     def name(self) -> str:

--- a/adcc/AdcMethod.py
+++ b/adcc/AdcMethod.py
@@ -20,8 +20,10 @@
 ## along with adcc. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## ---------------------------------------------------------------------
-from typing import Optional, Union, TypeVar
+from collections import Counter
+from typing import Any, Optional, Union, TypeVar
 from enum import Enum
+
 
 T = TypeVar("T", bound="Method")
 
@@ -85,7 +87,7 @@ class Method:
 
         assert self._base_method == split[-1]
 
-        # validate prefix
+        # validate prefixes
         split = split[:-1]
         valid_prefixes: tuple[str, ...] = ("cvs",)
         if len(split) > len(valid_prefixes):
@@ -93,6 +95,9 @@ class Method:
                              f"in {split}.")
         if any(pref not in valid_prefixes for pref in split):
             raise ValueError(f"Invalid method prefix in {split}.")
+        if any(count != 1 for count in Counter(split).values()):
+            raise ValueError(f"Invalid method string {method}. Duplicate "
+                             f"prefix detected in {split}.")
 
         self.is_core_valence_separated: bool = "cvs" in split
         # NOTE: added this to make the testdata generation ready for IP/EA
@@ -163,14 +168,18 @@ class Method:
             self.name.replace(self._method_base_name, method_cls._method_base_name)
         )
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, Method):
+            return NotImplemented
         return self.name == other.name
 
-    def __ne__(self, other):
+    def __ne__(self, other: Any):
+        if not isinstance(other, Method):
+            return NotImplemented
         return self.name != other.name
 
-    def __repr__(self):
-        return "Method(name={})".format(self.name)
+    def __repr__(self) -> str:
+        return f"Method(name={self.name})"
 
 
 class AdcMethod(Method):

--- a/adcc/AdcMethod.py
+++ b/adcc/AdcMethod.py
@@ -97,11 +97,14 @@ class GroundStateType(Enum):
             return False
 
 
+_level_key = tuple[AdcType, GroundStateType, bool]
+
+
 class Method:
     # this has to be set on the child classes
     _method_base_name: Optional[str] = None
-    max_level: int = 0
-    special_levels: tuple[MethodLevel, ...] = tuple()
+    _max_levels: dict[_level_key, int] = {}
+    _special_levels: dict[_level_key, tuple[MethodLevel, ...]] = {}
 
     def __init__(self, method: str):
         """
@@ -172,13 +175,18 @@ class Method:
         self._validate_level(self.level)
 
     def _validate_level(self, level: MethodLevel) -> None:
-        if isinstance(level.value, int) and level.value <= self.max_level:
-            return
-
-        # special cases
-        if level in self.special_levels:
-            return
-
+        # the common key for the lookup of the max level and special level
+        # depending on the parsed method string
+        key = (self.adc_type, self.gs_type, self.is_core_valence_separated)
+        if isinstance(level.value, int):
+            max_level = self._max_levels.get(key, None)
+            if max_level is not None and level.value <= max_level:
+                return
+        else:
+            # we have a special method
+            special_levels = self._special_levels.get(key, None)
+            if special_levels is not None and level in special_levels:
+                return
         raise NotImplementedError(f"{self.name} method is not implemented.")
 
     @property
@@ -260,11 +268,31 @@ class Method:
 
 class AdcMethod(Method):
     _method_base_name = "adc"
-    max_level = 3
-    special_levels = (MethodLevel.TWO_X,)
+    _max_levels = {
+        # adc_type,      gs_type,         cvs
+        (AdcType.PP, GroundStateType.MP, False): 3,
+        (AdcType.PP, GroundStateType.MP, True): 3
+    }
+    _special_levels = {
+        # adc_type,      gs_type,         cvs
+        (AdcType.PP, GroundStateType.MP, False): (MethodLevel.TWO_X,),
+        (AdcType.PP, GroundStateType.MP, True): (MethodLevel.TWO_X,)
+    }
 
 
 class IsrMethod(Method):
     _method_base_name = "isr"
-    max_level = 2
-    special_levels = (MethodLevel.ONE_S, MethodLevel.TWO_D)
+    _max_levels = {
+        # adc_type,      gs_type,         cvs
+        (AdcType.PP, GroundStateType.MP, False): 2,
+        (AdcType.PP, GroundStateType.MP, True): 2
+    }
+    _special_levels = {
+        # adc_type,      gs_type,         cvs
+        (AdcType.PP, GroundStateType.MP, False): (
+            MethodLevel.ONE_S, MethodLevel.TWO_D
+        ),
+        (AdcType.PP, GroundStateType.MP, True): (
+            MethodLevel.ONE_S, MethodLevel.TWO_D
+        )
+    }

--- a/adcc/AdcMethod.py
+++ b/adcc/AdcMethod.py
@@ -67,6 +67,20 @@ class MethodLevel(Enum):
             raise ValueError(f"Unknown value type {type(self.value)}.")
 
 
+class AdcType(Enum):
+    PP = "pp"
+
+    def to_str(self) -> str:
+        return self.value
+
+
+class GroundStateType(Enum):
+    MP = "mp"
+
+    def to_str(self) -> str:
+        return self.value
+
+
 class Method:
     # this has to be set on the child classes
     _method_base_name: Optional[str] = None
@@ -87,13 +101,18 @@ class Method:
             self.level: MethodLevel = MethodLevel(int(level))
         else:
             self.level: MethodLevel = MethodLevel(level)
-        self._validate_level(self.level)
 
-        assert self._base_method == split[-1]
-
-        # validate prefixes
         split = split[:-1]
-        valid_prefixes: tuple[str, ...] = ("cvs",)
+        # validate and set the adc_type
+        try:
+            self.adc_type: AdcType = AdcType(split[-1])
+            split = split[:-1]
+        except (ValueError, IndexError):
+            self.adc_type: AdcType = AdcType("pp")
+
+        self._validate_level(self.level)
+        # validate prefixes
+        valid_prefixes: tuple[str, ...] = ("cvs", "mp")
         if len(split) > len(valid_prefixes):
             raise ValueError("Invalid number of method prefixes provided "
                              f"in {split}.")
@@ -102,10 +121,21 @@ class Method:
         if any(count != 1 for count in Counter(split).values()):
             raise ValueError(f"Invalid method string {method}. Duplicate "
                              f"prefix detected in {split}.")
-
+        # set and remove cvs
         self.is_core_valence_separated: bool = "cvs" in split
-        # NOTE: added this to make the testdata generation ready for IP/EA
-        self.adc_type: str = "pp"
+        if "cvs" in split:
+            split.remove("cvs")
+        # finally set and validate gs type (the only allowed prefix left
+        # at this point)
+        if split:
+            self.gs_type: GroundStateType = GroundStateType(split[0])
+            split.pop(0)
+        else:
+            self.gs_type: GroundStateType = GroundStateType("mp")
+        # at this point all prefixes should have been handled
+        if split:
+            raise ValueError(f"Invalid prefix in {split} detected."
+                             f"Parsed from method string {method}.")
 
     def _validate_level(self, level: MethodLevel) -> None:
         if isinstance(level.value, int) and level.value <= self.max_level:
@@ -128,7 +158,13 @@ class Method:
     @property
     def _base_method(self) -> str:
         assert self._method_base_name is not None
-        return self._method_base_name + self.level.to_str()
+        if self.adc_type is AdcType.PP:
+            return f"{self._method_base_name}{self.level.to_str()}"
+        else:
+            return (
+                f"{self.adc_type.to_str()}-"
+                f"{self._method_base_name}{self.level.to_str()}"
+            )
 
     @property
     def prefixes(self) -> str:
@@ -136,6 +172,8 @@ class Method:
         ret = []
         if self.is_core_valence_separated:
             ret.append("cvs")
+        if self.gs_type is not GroundStateType.MP:
+            ret.append(self.gs_type.to_str())
         return "-".join(ret)
 
     @property

--- a/adcc/AdcMethod.py
+++ b/adcc/AdcMethod.py
@@ -21,6 +21,7 @@
 ##
 ## ---------------------------------------------------------------------
 from collections import Counter
+from dataclasses import dataclass
 from typing import Any, Optional, Union, TypeVar
 from enum import Enum
 
@@ -97,14 +98,28 @@ class GroundStateType(Enum):
             return False
 
 
-_level_key = tuple[AdcType, GroundStateType, bool]
+@dataclass(frozen=True)
+class LevelSpec:
+    max_level: Optional[int] = None
+    special_levels: tuple[MethodLevel, ...] = tuple()
+
+    def supports(self, level: MethodLevel) -> bool:
+        if isinstance(level.value, int):
+            return self.max_level is not None and level.value <= self.max_level
+        return level in self.special_levels
+
+
+@dataclass(frozen=True)
+class LevelKey:
+    adc_type: AdcType
+    gs_type: GroundStateType
+    cvs: bool
 
 
 class Method:
     # this has to be set on the child classes
     _method_base_name: Optional[str] = None
-    _max_levels: dict[_level_key, int] = {}
-    _special_levels: dict[_level_key, tuple[MethodLevel, ...]] = {}
+    _supported_levels: dict[LevelKey, LevelSpec] = {}
 
     def __init__(self, method: str):
         """
@@ -175,18 +190,13 @@ class Method:
         self._validate_level(self.level)
 
     def _validate_level(self, level: MethodLevel) -> None:
-        # the common key for the lookup of the max level and special level
-        # depending on the parsed method string
-        key = (self.adc_type, self.gs_type, self.is_core_valence_separated)
-        if isinstance(level.value, int):
-            max_level = self._max_levels.get(key, None)
-            if max_level is not None and level.value <= max_level:
-                return
-        else:
-            # we have a special method
-            special_levels = self._special_levels.get(key, None)
-            if special_levels is not None and level in special_levels:
-                return
+        key = LevelKey(
+            adc_type=self.adc_type, gs_type=self.gs_type,
+            cvs=self.is_core_valence_separated
+        )
+        spec = self._supported_levels.get(key, None)
+        if spec is not None and spec.supports(level):
+            return
         raise NotImplementedError(f"{self.name} method is not implemented.")
 
     @property
@@ -268,31 +278,43 @@ class Method:
 
 class AdcMethod(Method):
     _method_base_name = "adc"
-    _max_levels = {
-        # adc_type,      gs_type,         cvs
-        (AdcType.PP, GroundStateType.MP, False): 3,
-        (AdcType.PP, GroundStateType.MP, True): 3
-    }
-    _special_levels = {
-        # adc_type,      gs_type,         cvs
-        (AdcType.PP, GroundStateType.MP, False): (MethodLevel.TWO_X,),
-        (AdcType.PP, GroundStateType.MP, True): (MethodLevel.TWO_X,)
+    _supported_levels = {
+        LevelKey(
+            adc_type=AdcType.PP,
+            gs_type=GroundStateType.MP,
+            cvs=False
+        ): LevelSpec(
+            max_level=3,
+            special_levels=(MethodLevel.TWO_X,)
+        ),
+        LevelKey(
+            adc_type=AdcType.PP,
+            gs_type=GroundStateType.MP,
+            cvs=True
+        ): LevelSpec(
+            max_level=3,
+            special_levels=(MethodLevel.TWO_X,)
+        )
     }
 
 
 class IsrMethod(Method):
     _method_base_name = "isr"
-    _max_levels = {
-        # adc_type,      gs_type,         cvs
-        (AdcType.PP, GroundStateType.MP, False): 2,
-        (AdcType.PP, GroundStateType.MP, True): 2
-    }
-    _special_levels = {
-        # adc_type,      gs_type,         cvs
-        (AdcType.PP, GroundStateType.MP, False): (
-            MethodLevel.ONE_S, MethodLevel.TWO_D
+    _supported_levels = {
+        LevelKey(
+            adc_type=AdcType.PP,
+            gs_type=GroundStateType.MP,
+            cvs=False
+        ): LevelSpec(
+            max_level=2,
+            special_levels=(MethodLevel.ONE_S, MethodLevel.TWO_D)
         ),
-        (AdcType.PP, GroundStateType.MP, True): (
-            MethodLevel.ONE_S, MethodLevel.TWO_D
+        LevelKey(
+            adc_type=AdcType.PP,
+            gs_type=GroundStateType.MP,
+            cvs=True
+        ): LevelSpec(
+            max_level=2,
+            special_levels=(MethodLevel.ONE_S, MethodLevel.TWO_D)
         )
     }

--- a/adcc/ExcitedStates.py
+++ b/adcc/ExcitedStates.py
@@ -24,6 +24,7 @@ import numpy as np
 from scipy import constants
 
 from .import adc_pp
+from .AdcMethod import AdcType
 from .ElectronicStates import TableColumn
 from .ElectronicTransition import ElectronicTransition
 from .functions import dot
@@ -35,7 +36,7 @@ class ExcitedStates(ElectronicTransition):
     def __init__(self, data, method: str = None, property_method: str = None):
         super().__init__(data, method, property_method)
 
-        if self.method.adc_type != "pp":
+        if self.method.adc_type is not AdcType.PP:
             raise ValueError("ExcitedStates computes excited state properties "
                              "for PP-ADC. Got the non-PP-ADC method "
                              f"{self.method.name}")

--- a/adcc/IsrMatrix.py
+++ b/adcc/IsrMatrix.py
@@ -35,7 +35,6 @@ from .timings import Timer, timed_member_call
 
 
 class IsrMatrix(AdcMatrixlike):
-
     def __init__(self, method, hf_or_mp, operator, block_orders=None):
         """
         Initialise an ISR matrix of a given one-particle operator
@@ -83,7 +82,11 @@ class IsrMatrix(AdcMatrixlike):
         self.ndim = 2
         self.extra_terms = []
 
-        self.block_orders = self._default_block_orders(self.method)
+        n_particle_op = self.operator[0].n_particle_op
+        assert all(op.n_particle_op == n_particle_op for op in self.operator)
+        self.block_orders = self._default_block_orders(
+            self.method, n_zeroth_order_off_diag_couplings=n_particle_op
+        )
         if block_orders is None:
             # only implemented through PP-ADC(2)
             if method.adc_type != "pp":

--- a/adcc/IsrMatrix.py
+++ b/adcc/IsrMatrix.py
@@ -85,7 +85,7 @@ class IsrMatrix(AdcMatrixlike):
         n_particle_op = self.operator[0].n_particle_op
         assert all(op.n_particle_op == n_particle_op for op in self.operator)
         self.block_orders = self._default_block_orders(
-            self.method, n_zeroth_order_off_diag_couplings=n_particle_op
+            self.method, bandwidth=n_particle_op
         )
         if block_orders is None:
             # only implemented through PP-ADC(2)

--- a/adcc/IsrMatrix.py
+++ b/adcc/IsrMatrix.py
@@ -25,7 +25,7 @@ import libadcc
 from itertools import product
 
 from .AdcMatrix import AdcMatrixlike
-from .AdcMethod import IsrMethod
+from .AdcMethod import IsrMethod, AdcType
 from .adc_pp import bmatrix as ppbmatrix
 from .AmplitudeVector import AmplitudeVector
 from .LazyMp import LazyMp
@@ -89,7 +89,7 @@ class IsrMatrix(AdcMatrixlike):
         )
         if block_orders is None:
             # only implemented through PP-ADC(2)
-            if method.adc_type != "pp":
+            if method.adc_type is not AdcType.PP:
                 raise NotImplementedError("The B-matrix is not implemented "
                                           f"for method {method.name}.")
         else:

--- a/adcc/State2States.py
+++ b/adcc/State2States.py
@@ -23,6 +23,7 @@
 import numpy as np
 
 from . import adc_pp
+from .AdcMethod import AdcType
 from .ElectronicStates import _timer_name
 from .ElectronicTransition import ElectronicTransition
 from .misc import cached_member_function
@@ -63,7 +64,7 @@ class State2States(ElectronicTransition):
 
         # Since this class should be used for all adc_types we have to determine
         # the module according to the method.
-        if self.method.adc_type == "pp":
+        if self.method.adc_type is AdcType.PP:
             self._module = adc_pp
         else:
             raise ValueError(f"Unknown adc_type {self.method.adc_type}.")

--- a/adcc/adc_pp/modified_transition_moments.py
+++ b/adcc/adc_pp/modified_transition_moments.py
@@ -82,6 +82,7 @@ DISPATCH = {
     "isr1s": mtm_isr1,  # Identical to ISR(1)
     "isr1": mtm_isr1,
     "isr2": mtm_isr2,
+    "isr2d": mtm_isr2,  # Identical to ISR(2)
     "cvs-isr0": mtm_cvs_isr0,
     "cvs-isr1s": mtm_cvs_isr0,  # Identical to CVS-ISR(0)
     "cvs-isr1": mtm_cvs_isr0,  # Identical to CVS-ISR(0)

--- a/adcc/adc_pp/modified_transition_moments.py
+++ b/adcc/adc_pp/modified_transition_moments.py
@@ -81,11 +81,12 @@ DISPATCH = {
     "isr0": mtm_isr0,
     "isr1s": mtm_isr1,  # Identical to ISR(1)
     "isr1": mtm_isr1,
-    "isr2": mtm_isr2,
     "isr2d": mtm_isr2,  # Identical to ISR(2)
+    "isr2": mtm_isr2,
     "cvs-isr0": mtm_cvs_isr0,
     "cvs-isr1s": mtm_cvs_isr0,  # Identical to CVS-ISR(0)
     "cvs-isr1": mtm_cvs_isr0,  # Identical to CVS-ISR(0)
+    "cvs-isr2d": mtm_cvs_isr2,  # Identical to CVS-ISR(2)
     "cvs-isr2": mtm_cvs_isr2,
 }
 

--- a/adcc/adc_pp/state2state_transition_dm.py
+++ b/adcc/adc_pp/state2state_transition_dm.py
@@ -117,11 +117,13 @@ def s2s_tdm_isr2(mp, amplitude_l, amplitude_r, intermediates):
 
 
 # Ref: https://doi.org/10.1080/00268976.2013.859313
-DISPATCH = {"isr0": s2s_tdm_isr0,
-            "isr1s": s2s_tdm_isr0,  # Identical to ISR(0)
-            "isr1": s2s_tdm_isr1,
-            "isr2": s2s_tdm_isr2,
-            }
+DISPATCH = {
+    "isr0": s2s_tdm_isr0,
+    "isr1s": s2s_tdm_isr0,  # Identical to ISR(0)
+    "isr1": s2s_tdm_isr1,
+    "isr2": s2s_tdm_isr2,
+    "isr2d": s2s_tdm_isr2,  # Identical to ISR(2)
+}
 
 
 def state2state_transition_dm(method, ground_state, amplitude_from,

--- a/adcc/adc_pp/state2state_transition_dm.py
+++ b/adcc/adc_pp/state2state_transition_dm.py
@@ -121,8 +121,8 @@ DISPATCH = {
     "isr0": s2s_tdm_isr0,
     "isr1s": s2s_tdm_isr0,  # Identical to ISR(0)
     "isr1": s2s_tdm_isr1,
-    "isr2": s2s_tdm_isr2,
     "isr2d": s2s_tdm_isr2,  # Identical to ISR(2)
+    "isr2": s2s_tdm_isr2,
 }
 
 

--- a/adcc/adc_pp/state_diffdm.py
+++ b/adcc/adc_pp/state_diffdm.py
@@ -165,6 +165,7 @@ DISPATCH = {
     "isr1s": diffdm_isr0,   # Identical to ISR(0)
     "isr1": diffdm_isr1,
     "isr2": diffdm_isr2,
+    "isr2d": diffdm_isr2,  # Identical to ISR(2)
     "cvs-isr0": diffdm_isr0,
     "cvs-isr1s": diffdm_isr0,   # Identical to ISR(0)
     "cvs-isr1": diffdm_cvs_isr1,

--- a/adcc/adc_pp/state_diffdm.py
+++ b/adcc/adc_pp/state_diffdm.py
@@ -164,11 +164,12 @@ DISPATCH = {
     "isr0": diffdm_isr0,
     "isr1s": diffdm_isr0,   # Identical to ISR(0)
     "isr1": diffdm_isr1,
-    "isr2": diffdm_isr2,
     "isr2d": diffdm_isr2,  # Identical to ISR(2)
+    "isr2": diffdm_isr2,
     "cvs-isr0": diffdm_isr0,
     "cvs-isr1s": diffdm_isr0,   # Identical to ISR(0)
     "cvs-isr1": diffdm_cvs_isr1,
+    "cvs-isr2d": diffdm_cvs_isr2,  # Identical to CVS-ISR(2)
     "cvs-isr2": diffdm_cvs_isr2,
 }
 

--- a/adcc/adc_pp/state_diffdm_2p.py
+++ b/adcc/adc_pp/state_diffdm_2p.py
@@ -20,16 +20,17 @@
 ## along with adcc. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## ---------------------------------------------------------------------
-from adcc import block as b
-from adcc.LazyMp import LazyMp
-from adcc.AdcMethod import IsrMethod
-from adcc.functions import einsum, zeros_like
-from adcc.Intermediates import Intermediates
-from adcc.AmplitudeVector import AmplitudeVector
-from adcc.TwoParticleDensity import TwoParticleDensity
-from adcc.NParticleOperator import OperatorSymmetry
-
-from .util import check_doubles_amplitudes, check_singles_amplitudes
+from .. import block as b
+from ..LazyMp import LazyMp
+from ..AdcMethod import IsrMethod
+from ..functions import einsum, zeros_like
+from ..Intermediates import Intermediates
+from ..AmplitudeVector import AmplitudeVector
+from ..TwoParticleDensity import TwoParticleDensity
+from ..NParticleOperator import OperatorSymmetry
+from .util import (
+    check_doubles_amplitudes, check_singles_amplitudes, check_triples_amplitudes
+)
 
 
 def diffdm_isr0_2p(mp, amplitude, intermediates):
@@ -126,7 +127,7 @@ def diffdm_isr1_2p(mp, amplitude, intermediates):
     return dm
 
 
-def diffdm_isr2_2p(mp, amplitude, intermediates):
+def diffdm_isr2d_2p(mp, amplitude, intermediates):
     dm = diffdm_isr1_2p(mp, amplitude, intermediates)  # Get ISR(1) result
     check_doubles_amplitudes([b.o, b.o, b.v, b.v], amplitude)
     u1, u2 = amplitude.ph, amplitude.pphh
@@ -364,11 +365,27 @@ def diffdm_isr2_2p(mp, amplitude, intermediates):
     return dm
 
 
+def diffdm_isr2_2p(mp: LazyMp, amplitude: AmplitudeVector,
+                   intermediates: Intermediates) -> TwoParticleDensity:
+    dm = diffdm_isr2d_2p(mp, amplitude, intermediates)  # Get ISR(1) result
+    # evaluate additional contributions from the S-T block
+    # if the vector has a triples component
+    try:
+        check_triples_amplitudes([b.o, b.o, b.o, b.v, b.v, b.v], amplitude)
+    except ValueError:
+        return dm
+    u1, u3 = amplitude.ph, amplitude.ppphhh
+    # N^6: O^3V^3 / N^6: O^3V^3
+    dm.oovv += - 6 * einsum("kc,ijkabc->ijab", u1, u3)
+    return dm
+
+
 # dict controlling the dispatch of the state_diffdm function
 DISPATCH = {
     "isr0": diffdm_isr0_2p,
     "isr1s": diffdm_isr1s_2p,
     "isr1": diffdm_isr1_2p,
+    "isr2d": diffdm_isr2d_2p,
     "isr2": diffdm_isr2_2p,
 }
 

--- a/adcc/adc_pp/state_diffdm_2p.py
+++ b/adcc/adc_pp/state_diffdm_2p.py
@@ -32,8 +32,11 @@ from .util import (
     check_doubles_amplitudes, check_singles_amplitudes, check_triples_amplitudes
 )
 
+from typing import Optional, Union
 
-def diffdm_isr0_2p(mp, amplitude, intermediates):
+
+def diffdm_isr0_2p(mp: LazyMp, amplitude: AmplitudeVector,
+                   intermediates: Intermediates) -> TwoParticleDensity:
     check_singles_amplitudes([b.o, b.v], amplitude)
     u1 = amplitude.ph
 
@@ -60,7 +63,8 @@ def diffdm_isr0_2p(mp, amplitude, intermediates):
     return dm
 
 
-def diffdm_isr1s_2p(mp, amplitude, intermediates):
+def diffdm_isr1s_2p(mp: LazyMp, amplitude: AmplitudeVector,
+                    intermediates: Intermediates) -> TwoParticleDensity:
     dm = diffdm_isr0_2p(mp, amplitude, intermediates)  # Get ISR(0) result
     u1 = amplitude.ph
 
@@ -96,7 +100,8 @@ def diffdm_isr1s_2p(mp, amplitude, intermediates):
     return dm
 
 
-def diffdm_isr1_2p(mp, amplitude, intermediates):
+def diffdm_isr1_2p(mp: LazyMp, amplitude: AmplitudeVector,
+                   intermediates: Intermediates) -> TwoParticleDensity:
     dm = diffdm_isr1s_2p(mp, amplitude, intermediates)  # Get ISR(1)-s result
 
     try:
@@ -127,7 +132,8 @@ def diffdm_isr1_2p(mp, amplitude, intermediates):
     return dm
 
 
-def diffdm_isr2d_2p(mp, amplitude, intermediates):
+def diffdm_isr2d_2p(mp: LazyMp, amplitude: AmplitudeVector,
+                    intermediates: Intermediates) -> TwoParticleDensity:
     dm = diffdm_isr1_2p(mp, amplitude, intermediates)  # Get ISR(1) result
     check_doubles_amplitudes([b.o, b.o, b.v, b.v], amplitude)
     u1, u2 = amplitude.ph, amplitude.pphh
@@ -390,7 +396,9 @@ DISPATCH = {
 }
 
 
-def state_diffdm_2p(method, ground_state, amplitude, intermediates=None):
+def state_diffdm_2p(method: Union[str, IsrMethod], ground_state: LazyMp,
+                    amplitude: AmplitudeVector,
+                    intermediates: Optional[Intermediates] = None):
     """
     Compute the two-particle difference density matrix of an excited state
     in the MO basis.

--- a/adcc/adc_pp/state_diffdm_2p.py
+++ b/adcc/adc_pp/state_diffdm_2p.py
@@ -373,7 +373,7 @@ def diffdm_isr2d_2p(mp: LazyMp, amplitude: AmplitudeVector,
 
 def diffdm_isr2_2p(mp: LazyMp, amplitude: AmplitudeVector,
                    intermediates: Intermediates) -> TwoParticleDensity:
-    dm = diffdm_isr2d_2p(mp, amplitude, intermediates)  # Get ISR(1) result
+    dm = diffdm_isr2d_2p(mp, amplitude, intermediates)  # Get ISR(2)-d result
     # evaluate additional contributions from the S-T block
     # if the vector has a triples component
     try:

--- a/adcc/adc_pp/transition_dm.py
+++ b/adcc/adc_pp/transition_dm.py
@@ -105,6 +105,7 @@ DISPATCH = {
     "isr1s": tdm_isr1,  # Identical to ISR(1)
     "isr1": tdm_isr1,
     "isr2": tdm_isr2,
+    "isr2d": tdm_isr2,  # Identical to ISR(2)
     "cvs-isr0": tdm_isr0,
     "cvs-isr1": tdm_isr0,  # No extra contribs for CVS-ISR(1)
     "cvs-isr2": tdm_cvs_isr2,

--- a/adcc/adc_pp/transition_dm.py
+++ b/adcc/adc_pp/transition_dm.py
@@ -104,10 +104,11 @@ DISPATCH = {
     "isr0": tdm_isr0,
     "isr1s": tdm_isr1,  # Identical to ISR(1)
     "isr1": tdm_isr1,
-    "isr2": tdm_isr2,
     "isr2d": tdm_isr2,  # Identical to ISR(2)
+    "isr2": tdm_isr2,
     "cvs-isr0": tdm_isr0,
     "cvs-isr1": tdm_isr0,  # No extra contribs for CVS-ISR(1)
+    "cvs-isr2d": tdm_cvs_isr2,  # Identical to CVS-ISR(2)
     "cvs-isr2": tdm_cvs_isr2,
 }
 

--- a/adcc/adc_pp/util.py
+++ b/adcc/adc_pp/util.py
@@ -20,6 +20,7 @@
 ## along with adcc. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## ---------------------------------------------------------------------
+from ..AmplitudeVector import AmplitudeVector
 
 
 def check_singles_amplitudes(spaces, *amplitudes):
@@ -30,6 +31,11 @@ def check_singles_amplitudes(spaces, *amplitudes):
 def check_doubles_amplitudes(spaces, *amplitudes):
     check_have_doubles_block(*amplitudes)
     check_doubles_subspaces(spaces, *amplitudes)
+
+
+def check_triples_amplitudes(spaces: list[str], *amplitudes: AmplitudeVector):
+    check_have_triples_block(*amplitudes)
+    check_triples_subspaces(spaces, *amplitudes)
 
 
 def check_have_singles_block(*amplitudes):
@@ -44,6 +50,11 @@ def check_have_doubles_block(*amplitudes):
         raise ValueError("ADC(2) level and "
                          "beyond expects an excitation amplitude with a "
                          "singles and a doubles part.")
+
+
+def check_have_triples_block(*amplitudes: AmplitudeVector):
+    if any("ppphhh" not in amplitude.blocks for amplitude in amplitudes):
+        raise ValueError("Expected an excitation amplitude with a triples part.")
 
 
 def check_singles_subspaces(spaces, *amplitudes):
@@ -61,4 +72,13 @@ def check_doubles_subspaces(spaces, *amplitudes):
         if u2.subspaces != spaces:
             raise ValueError("Mismatch in subspaces doubles part "
                              f"(== {u2.subspaces}), where "
+                             f"{spaces} was expected.")
+
+
+def check_triples_subspaces(spaces: list[str], *amplitudes: AmplitudeVector):
+    for amplitude in amplitudes:
+        u3 = amplitude.ppphhh
+        if u3.subspaces != spaces:
+            raise ValueError("Mismatch in subspaces triples part "
+                             f"(== {u3.subspaces}), where "
                              f"{spaces} was expected.")

--- a/adcc/adc_pp/util.py
+++ b/adcc/adc_pp/util.py
@@ -23,12 +23,12 @@
 from ..AmplitudeVector import AmplitudeVector
 
 
-def check_singles_amplitudes(spaces, *amplitudes):
+def check_singles_amplitudes(spaces: list[str], *amplitudes: AmplitudeVector):
     check_have_singles_block(*amplitudes)
     check_singles_subspaces(spaces, *amplitudes)
 
 
-def check_doubles_amplitudes(spaces, *amplitudes):
+def check_doubles_amplitudes(spaces: list[str], *amplitudes: AmplitudeVector):
     check_have_doubles_block(*amplitudes)
     check_doubles_subspaces(spaces, *amplitudes)
 
@@ -38,14 +38,14 @@ def check_triples_amplitudes(spaces: list[str], *amplitudes: AmplitudeVector):
     check_triples_subspaces(spaces, *amplitudes)
 
 
-def check_have_singles_block(*amplitudes):
+def check_have_singles_block(*amplitudes: AmplitudeVector):
     if any("ph" not in amplitude.blocks for amplitude in amplitudes):
         raise ValueError("ADC(0) level and "
                          "beyond expects an excitation amplitude with a "
                          "singles part.")
 
 
-def check_have_doubles_block(*amplitudes):
+def check_have_doubles_block(*amplitudes: AmplitudeVector):
     if any("pphh" not in amplitude.blocks for amplitude in amplitudes):
         raise ValueError("ADC(2) level and "
                          "beyond expects an excitation amplitude with a "
@@ -57,7 +57,7 @@ def check_have_triples_block(*amplitudes: AmplitudeVector):
         raise ValueError("Expected an excitation amplitude with a triples part.")
 
 
-def check_singles_subspaces(spaces, *amplitudes):
+def check_singles_subspaces(spaces: list[str], *amplitudes: AmplitudeVector):
     for amplitude in amplitudes:
         u1 = amplitude.ph
         if u1.subspaces != spaces:
@@ -66,7 +66,7 @@ def check_singles_subspaces(spaces, *amplitudes):
                              "was expected.")
 
 
-def check_doubles_subspaces(spaces, *amplitudes):
+def check_doubles_subspaces(spaces: list[str], *amplitudes: AmplitudeVector):
     for amplitude in amplitudes:
         u2 = amplitude.pphh
         if u2.subspaces != spaces:

--- a/adcc/tests/AdcMatrix_test.py
+++ b/adcc/tests/AdcMatrix_test.py
@@ -28,7 +28,7 @@ from numpy.testing import assert_allclose
 from adcc.AdcMatrix import (
     AdcExtraTerm, AdcMatrixProjected, AdcMatrixShifted, AdcMatrixlike
 )
-from adcc.AdcMethod import AdcMethod
+from adcc.AdcMethod import AdcMethod, IsrMethod
 from adcc.Intermediates import Intermediates
 from adcc.adc_pp.matrix import AdcBlock
 
@@ -50,23 +50,75 @@ class TestBlockOrders:
         # verify the default methods
         for order in range(0, 4):
             block_orders = AdcMatrixlike._default_block_orders(
-                method=AdcMethod(f"adc{order}")
+                method=AdcMethod(f"adc{order}"), n_zeroth_order_off_diag_couplings=0
             )
             cvs_block_orders = AdcMatrixlike._default_block_orders(
-                method=AdcMethod(f"cvs-adc{order}")
+                method=AdcMethod(f"cvs-adc{order}"),
+                n_zeroth_order_off_diag_couplings=0
             )
             assert ref[order] == block_orders
             assert cvs_block_orders == block_orders
         # verify the special methods: adc2x
         block_orders = AdcMatrixlike._default_block_orders(
-            method=AdcMethod("adc2x")
+            method=AdcMethod("adc2x"), n_zeroth_order_off_diag_couplings=0
         )
         cvs_block_orders = AdcMatrixlike._default_block_orders(
-            method=AdcMethod("cvs-adc2x")
+            method=AdcMethod("cvs-adc2x"), n_zeroth_order_off_diag_couplings=0
         )
         ref = {"ph_ph": 2, "ph_pphh": 1, "pphh_ph": 1, "pphh_pphh": 1}
         assert block_orders == ref
         assert block_orders == cvs_block_orders
+        # also verify ISR matrices: 1-particle
+        ref = (
+            {"ph_ph": 0},  # ISR(0)
+            {"ph_ph": 1, "ph_pphh": 0, "pphh_ph": 0, "pphh_pphh": None},  # ISR(1)
+            {"ph_ph": 2, "ph_pphh": 1, "pphh_ph": 1, "pphh_pphh": 0}  # ISR(2)
+        )
+        for order in range(0, 3):
+            block_orders = AdcMatrixlike._default_block_orders(
+                method=IsrMethod(f"isr{order}"), n_zeroth_order_off_diag_couplings=1
+            )
+            cvs_block_orders = AdcMatrixlike._default_block_orders(
+                method=IsrMethod(f"cvs-isr{order}"),
+                n_zeroth_order_off_diag_couplings=1
+            )
+            assert ref[order] == block_orders
+            assert cvs_block_orders == block_orders
+        # also verify ISR matrices: 2-particle
+        ref = (
+            {"ph_ph": 0, "ph_pphh": None,
+             "pphh_ph": None, "pphh_pphh": None},  # ISR(0)
+            {"ph_ph": 1, "ph_pphh": 0, "pphh_ph": 0, "pphh_pphh": None},  # ISR(1)
+            {"ph_ph": 2, "ph_pphh": 1, "ph_ppphhh": 0,
+             "pphh_ph": 1, "pphh_pphh": 0, "pphh_ppphhh": None,
+             "ppphhh_ph": 0, "ppphhh_pphh": None, "ppphhh_ppphhh": None}  # ISR(2)
+        )
+        for order in range(0, 3):
+            block_orders = AdcMatrixlike._default_block_orders(
+                method=IsrMethod(f"isr{order}"), n_zeroth_order_off_diag_couplings=2
+            )
+            cvs_block_orders = AdcMatrixlike._default_block_orders(
+                method=IsrMethod(f"cvs-isr{order}"),
+                n_zeroth_order_off_diag_couplings=2
+            )
+            assert ref[order] == block_orders
+            assert cvs_block_orders == block_orders
+        # isr(1)-s
+        block_orders = AdcMatrixlike._default_block_orders(
+            method=IsrMethod("isr1s"), n_zeroth_order_off_diag_couplings=1
+        )
+        ref_isr1s = {
+            "ph_ph": 1, "ph_pphh": None, "pphh_ph": None, "pphh_pphh": None
+        }
+        assert block_orders == ref_isr1s
+        # isr(2)-d
+        block_orders = AdcMatrixlike._default_block_orders(
+            method=IsrMethod("isr2d"), n_zeroth_order_off_diag_couplings=2
+        )
+        ref_isr2d = {
+            "ph_ph": 2, "ph_pphh": 1, "pphh_ph": 1, "pphh_pphh": 0
+        }
+        assert block_orders == ref_isr2d
 
     def test_validate_block_orders(self):
         valid_block_orders = (

--- a/adcc/tests/AdcMatrix_test.py
+++ b/adcc/tests/AdcMatrix_test.py
@@ -28,7 +28,7 @@ from numpy.testing import assert_allclose
 from adcc.AdcMatrix import (
     AdcExtraTerm, AdcMatrixProjected, AdcMatrixShifted, AdcMatrixlike
 )
-from adcc.AdcMethod import AdcMethod, IsrMethod
+from adcc.AdcMethod import AdcMethod, IsrMethod, AdcType
 from adcc.Intermediates import Intermediates
 from adcc.adc_pp.matrix import AdcBlock
 
@@ -221,7 +221,7 @@ class TestAdcMatrix:
         # the matrix data is only dumped once and not per kind
         # -> singlet/any for PP-ADC
         if matrix.reference_state.restricted:
-            if matrix.method.adc_type == "pp":
+            if matrix.method.adc_type is AdcType.PP:
                 kind = "singlet"
             else:
                 raise ValueError(f"Unknown adc type {matrix.method.adc_type}.")
@@ -241,7 +241,7 @@ class TestAdcMatrix:
         # matrix data is only dumped once and not per kind
         # -> singlet/any for PP-ADC
         if matrix.reference_state.restricted:
-            if matrix.method.adc_type == "pp":
+            if matrix.method.adc_type is AdcType.PP:
                 kind = "singlet"
             else:
                 raise ValueError(f"Unknwon adc type {matrix.method.adc_type}.")
@@ -277,7 +277,7 @@ class TestAdcMatrixInterface:
         assert matrix.is_core_valence_separated == ("cvs" in case)
         # check that the blocks are correct
         blocks = matrix.axis_blocks
-        if matrix.method.adc_type == "pp":
+        if matrix.method.adc_type is AdcType.PP:
             assert blocks == (
                 ["ph", "pphh", "ppphhh"][:matrix.method.level.to_int() // 2 + 1]
             )

--- a/adcc/tests/AdcMatrix_test.py
+++ b/adcc/tests/AdcMatrix_test.py
@@ -50,20 +50,20 @@ class TestBlockOrders:
         # verify the default methods
         for order in range(0, 4):
             block_orders = AdcMatrixlike._default_block_orders(
-                method=AdcMethod(f"adc{order}"), n_zeroth_order_off_diag_couplings=0
+                method=AdcMethod(f"adc{order}"), bandwidth=0
             )
             cvs_block_orders = AdcMatrixlike._default_block_orders(
                 method=AdcMethod(f"cvs-adc{order}"),
-                n_zeroth_order_off_diag_couplings=0
+                bandwidth=0
             )
             assert ref[order] == block_orders
             assert cvs_block_orders == block_orders
         # verify the special methods: adc2x
         block_orders = AdcMatrixlike._default_block_orders(
-            method=AdcMethod("adc2x"), n_zeroth_order_off_diag_couplings=0
+            method=AdcMethod("adc2x"), bandwidth=0
         )
         cvs_block_orders = AdcMatrixlike._default_block_orders(
-            method=AdcMethod("cvs-adc2x"), n_zeroth_order_off_diag_couplings=0
+            method=AdcMethod("cvs-adc2x"), bandwidth=0
         )
         ref = {"ph_ph": 2, "ph_pphh": 1, "pphh_ph": 1, "pphh_pphh": 1}
         assert block_orders == ref
@@ -76,11 +76,11 @@ class TestBlockOrders:
         )
         for order in range(0, 3):
             block_orders = AdcMatrixlike._default_block_orders(
-                method=IsrMethod(f"isr{order}"), n_zeroth_order_off_diag_couplings=1
+                method=IsrMethod(f"isr{order}"), bandwidth=1
             )
             cvs_block_orders = AdcMatrixlike._default_block_orders(
                 method=IsrMethod(f"cvs-isr{order}"),
-                n_zeroth_order_off_diag_couplings=1
+                bandwidth=1
             )
             assert ref[order] == block_orders
             assert cvs_block_orders == block_orders
@@ -95,17 +95,17 @@ class TestBlockOrders:
         )
         for order in range(0, 3):
             block_orders = AdcMatrixlike._default_block_orders(
-                method=IsrMethod(f"isr{order}"), n_zeroth_order_off_diag_couplings=2
+                method=IsrMethod(f"isr{order}"), bandwidth=2
             )
             cvs_block_orders = AdcMatrixlike._default_block_orders(
                 method=IsrMethod(f"cvs-isr{order}"),
-                n_zeroth_order_off_diag_couplings=2
+                bandwidth=2
             )
             assert ref[order] == block_orders
             assert cvs_block_orders == block_orders
         # isr(1)-s
         block_orders = AdcMatrixlike._default_block_orders(
-            method=IsrMethod("isr1s"), n_zeroth_order_off_diag_couplings=1
+            method=IsrMethod("isr1s"), bandwidth=1
         )
         ref_isr1s = {
             "ph_ph": 1, "ph_pphh": None, "pphh_ph": None, "pphh_pphh": None
@@ -113,7 +113,7 @@ class TestBlockOrders:
         assert block_orders == ref_isr1s
         # isr(2)-d
         block_orders = AdcMatrixlike._default_block_orders(
-            method=IsrMethod("isr2d"), n_zeroth_order_off_diag_couplings=2
+            method=IsrMethod("isr2d"), bandwidth=2
         )
         ref_isr2d = {
             "ph_ph": 2, "ph_pphh": 1, "pphh_ph": 1, "pphh_pphh": 0

--- a/adcc/tests/AdcMethod_test.py
+++ b/adcc/tests/AdcMethod_test.py
@@ -22,13 +22,16 @@
 ## ---------------------------------------------------------------------
 import pytest
 
-import adcc
+from adcc.AdcMethod import AdcMethod, AdcType, GroundStateType, IsrMethod
+
 
 adc_methods = [("adc1", None), ("adc2x", None), ("cvs-adc3", None),
                ("adc", ValueError), ("cvs_adc2", ValueError),
                ("xyz-adc2", ValueError), ("adc5", NotImplementedError),
                ("isr2", ValueError), ("mp-adc2", None), ("cvs-mp-adc2", None),
-               ("cvs-cvs-adc2", ValueError), ("adcc", ValueError)]
+               ("cvs-cvs-adc2", ValueError), ("adcc", ValueError),
+               ("pp-adc2", None), ("ee-adc2", ValueError),
+               ("mp-pp-adc2", None), ("pp-mp-adc2", ValueError)]
 
 isr_methods = [("isr1", None), ("cvs-isr2", None),
                ("adc", ValueError), ("cvs_isr2", ValueError),
@@ -41,23 +44,32 @@ class TestAdcMethod:
     def test_validate_adcmethod(self, method, expected_exception):
         if expected_exception:
             with pytest.raises(expected_exception):
-                adcc.AdcMethod(method)
+                AdcMethod(method)
         else:
-            adc_method = adcc.AdcMethod(method)
-            assert adc_method.name == method.replace("mp-", "")
+            adc_method = AdcMethod(method)
+            assert adc_method.name == method.replace("mp-", "").replace("pp-", "")
+            assert adc_method.adc_type is AdcType.PP
+            assert adc_method.gs_type is GroundStateType.MP
 
     def test_adcmethod(self):
-        method = adcc.AdcMethod("adc2")
-        cvs_method = adcc.AdcMethod("cvs-adc2")
+        method = AdcMethod("adc2")
+        cvs_method = AdcMethod("cvs-adc2")
 
         assert method.name == cvs_method.base_method.name
+        assert method.adc_type is AdcType.PP
+        assert method.gs_type is GroundStateType.MP
 
         method_new_level = method.at_level(1)
         assert method_new_level._method_base_name == method._method_base_name
         assert method_new_level.level.to_int() == 1
+        assert method_new_level.adc_type is AdcType.PP
+        assert method_new_level.gs_type is GroundStateType.MP
 
-        as_isr_method = method.as_method(adcc.IsrMethod)
-        assert isinstance(as_isr_method, adcc.IsrMethod)
+        as_isr_method = method.as_method(IsrMethod)
+        assert isinstance(as_isr_method, IsrMethod)
+        assert as_isr_method.name == "isr2"
+        assert as_isr_method.adc_type is AdcType.PP
+        assert as_isr_method.gs_type is GroundStateType.MP
 
 
 class TestIsrMethod:
@@ -65,20 +77,26 @@ class TestIsrMethod:
     def test_validate_isrmethod(self, method, expected_exception):
         if expected_exception:
             with pytest.raises(expected_exception):
-                adcc.IsrMethod(method)
+                IsrMethod(method)
         else:
-            isr_method = adcc.IsrMethod(method)
+            isr_method = IsrMethod(method)
             assert isr_method.name == method
+            assert isr_method.adc_type is AdcType.PP
+            assert isr_method.gs_type is GroundStateType.MP
 
     def test_isrmethod(self):
-        method = adcc.IsrMethod("isr2")
-        cvs_method = adcc.IsrMethod("cvs-isr2")
+        method = IsrMethod("isr2")
+        cvs_method = IsrMethod("cvs-isr2")
 
         assert method.name == cvs_method.base_method.name
 
         method_new_level = method.at_level(1)
         assert method_new_level._method_base_name == method._method_base_name
         assert method_new_level.level.to_int() == 1
+        assert method.adc_type is AdcType.PP
+        assert method.gs_type is GroundStateType.MP
 
-        as_adc_method = method.as_method(adcc.AdcMethod)
-        assert isinstance(as_adc_method, adcc.AdcMethod)
+        as_adc_method = method.as_method(AdcMethod)
+        assert isinstance(as_adc_method, AdcMethod)
+        assert as_adc_method.adc_type is AdcType.PP
+        assert as_adc_method.gs_type is GroundStateType.MP

--- a/adcc/tests/AdcMethod_test.py
+++ b/adcc/tests/AdcMethod_test.py
@@ -27,7 +27,8 @@ import adcc
 adc_methods = [("adc1", None), ("adc2x", None), ("cvs-adc3", None),
                ("adc", ValueError), ("cvs_adc2", ValueError),
                ("xyz-adc2", ValueError), ("adc5", NotImplementedError),
-               ("isr2", ValueError)]
+               ("isr2", ValueError), ("mp-adc2", None), ("cvs-mp-adc2", None),
+               ("cvs-cvs-adc2", ValueError), ("adcc", ValueError)]
 
 isr_methods = [("isr1", None), ("cvs-isr2", None),
                ("adc", ValueError), ("cvs_isr2", ValueError),
@@ -43,7 +44,7 @@ class TestAdcMethod:
                 adcc.AdcMethod(method)
         else:
             adc_method = adcc.AdcMethod(method)
-            assert adc_method.name == method
+            assert adc_method.name == method.replace("mp-", "")
 
     def test_adcmethod(self):
         method = adcc.AdcMethod("adc2")

--- a/adcc/tests/generators/generate_adcc_data.py
+++ b/adcc/tests/generators/generate_adcc_data.py
@@ -126,7 +126,7 @@ def generate_h2o_sto3g():
         for n_states in \
                 testcases.kinds_to_nstates(test_case.kinds[method.adc_type]):
             per_case = None
-            if method.level < 2:  # adc0/adc1
+            if method.level.to_int() < 2:  # adc0/adc1
                 per_case = {
                     case: {n_states: n} for case, n in states_per_case.items()
                 }
@@ -135,7 +135,7 @@ def generate_h2o_sto3g():
             # 4 states available
             # -> reduce n_guesses for all ADC(2) and ADC(3) calculations
             kwargs = {}
-            if method.level >= 2:
+            if method.level.to_int() >= 2:
                 kwargs = {"n_guesses": 4}
             generate_adc_all(
                 test_case, method=method, dump_nstates=2, states_per_case=per_case,

--- a/adcc/tests/generators/generate_adcman_data.py
+++ b/adcc/tests/generators/generate_adcman_data.py
@@ -1,7 +1,7 @@
 from adcc.tests.generators.run_qchem import run_qchem
 from adcc.tests import testcases
 
-from adcc.AdcMethod import AdcMethod
+from adcc.AdcMethod import AdcMethod, MethodLevel
 from adcc.hdf5io import emplace_dict
 
 from pathlib import Path
@@ -48,11 +48,12 @@ def generate_adc(test_case: testcases.TestCase, method: AdcMethod, case: str,
     if f"{case}/{gs_density_order}" in hdf5_file:
         return None
     # skip cvs-adc(0), since it is not available in qchem.
-    if "cvs" in case and method.level == 0:
+    if "cvs" in case and method.level is MethodLevel.ZERO:
         return None
     # gs_density_order is only available for adc(3) and adc(4)
     # and it is not available for cvs-adc
-    if gs_density_order is not None and (method.level < 3 or "cvs" in case):
+    if gs_density_order is not None and \
+            (method.level.to_int() < 3 or "cvs" in case):
         return None
     print(f"Generating {method.name} (gs_density_order={gs_density_order}) "
           f"data for {case} {test_case.file_name}.")

--- a/adcc/tests/generators/import_qchem_data.py
+++ b/adcc/tests/generators/import_qchem_data.py
@@ -1,4 +1,4 @@
-from adcc.AdcMethod import AdcMethod
+from adcc.AdcMethod import AdcMethod, AdcType
 from adcc.hdf5io import _extract_dataset
 
 from collections.abc import Hashable
@@ -73,7 +73,7 @@ def import_excited_states(context: h5py.File, method: AdcMethod,
     """
     # define the possible state kinds to import for each adc variant.
     state_kinds = {
-        "pp": [
+        AdcType.PP: [
             ("singlets", True), ("triplets", True),  # restricted
             # uhf and spin flip are located in the same ".../uhf/..." subtree
             ("any_or_spinflip", False),  # unrestricted
@@ -115,7 +115,7 @@ def import_excited_states(context: h5py.File, method: AdcMethod,
 
 
 def _import_excited_states(context: h5py.File, method: str, only_full_mode: bool,
-                           adc_type: str = "pp",
+                           adc_type: AdcType = AdcType.PP,
                            import_nstates: int | None = None,
                            state_kind: str | None = None, restricted: bool = True,
                            dims_pref: str = "dims/") -> None | dict[str, Any]:
@@ -135,7 +135,7 @@ def _import_excited_states(context: h5py.File, method: str, only_full_mode: bool
         Indicates whether the data to read is for a test case that only
         runs in full mode. Since these systems are typically quite large
         one might not want to import all data for these cases.
-    adc_type: str, optional
+    adc_type: AdcType, optional
         Which type of adc calculation has been performed, e.g., pp.
     import_nstates: int, optional
         Only import the first n states from the context.
@@ -150,7 +150,7 @@ def _import_excited_states(context: h5py.File, method: str, only_full_mode: bool
         prefix to the context tree of the object.
     """
     # build the path under which to find the exicted states
-    tree = [f"adc_{adc_type}", method]
+    tree = [f"adc_{adc_type.to_str()}", method]
     if restricted:
         assert state_kind is not None  # needs to be defined for restricted calcs
         tree.extend(["rhf", state_kind])
@@ -208,7 +208,7 @@ def _import_excited_states(context: h5py.File, method: str, only_full_mode: bool
 
 def _import_state_to_state_data(context: h5py.File, method: str,
                                 only_full_mode: bool,
-                                adc_type: str = "pp",
+                                adc_type: AdcType = AdcType.PP,
                                 import_nstates: int | None = None,
                                 state_kind: str | None = None,
                                 restricted: bool = True,
@@ -230,7 +230,7 @@ def _import_state_to_state_data(context: h5py.File, method: str,
         Indicates whether the data to read is for a test case that only
         runs in full mode. Since these systems are typically quite large
         one might not want to import all data for these cases.
-    adc_type: str, optional
+    adc_type: AdcType, optional
         Which type of adc calculation has been performed, e.g., pp.
     import_nstates: int, optional
         Only import the first n states from the context.
@@ -245,7 +245,7 @@ def _import_state_to_state_data(context: h5py.File, method: str,
         prefix to the context tree of the object.
     """
     # build the path under which to look for the state-to-state data.
-    tree = [f"adc_{adc_type}", method]
+    tree = [f"adc_{adc_type.to_str()}", method]
     if restricted:
         assert state_kind is not None  # needs to be defined for restricted calcs
         tree.extend(["rhf", "isr", state_kind])

--- a/adcc/tests/generators/run_qchem.py
+++ b/adcc/tests/generators/run_qchem.py
@@ -5,7 +5,7 @@ from adcc.tests.generators.qchem_savedir import QchemSavedir
 from adcc.tests import testcases
 
 from adcc.hdf5io import _extract_dataset
-from adcc.AdcMethod import AdcMethod
+from adcc.AdcMethod import AdcMethod, MethodLevel
 from adcc import ReferenceState
 
 from collections.abc import Sequence
@@ -62,11 +62,11 @@ def run_qchem(test_case: testcases.TestCase, method: AdcMethod, case: str,
     """
     # sanitize the input
     assert method.is_core_valence_separated == ("cvs" in case)
-    if method.is_core_valence_separated and method.level == 0:
+    if method.is_core_valence_separated and method.level is MethodLevel.ZERO:
         raise ValueError("CVS-ADC(0) is not available in adcman.")
 
     if kwargs.get("gs_density_order", None) is not None:
-        if method.level < 3:
+        if method.level.to_int() < 3:
             raise ValueError("gs_density_order is only available for ADC(n) with "
                              "n > 2")
         if method.is_core_valence_separated:

--- a/adcc/tests/projection_test.py
+++ b/adcc/tests/projection_test.py
@@ -28,6 +28,7 @@ import itertools
 import numpy as np
 from numpy.testing import assert_allclose
 
+from adcc.AdcMethod import AdcType
 from adcc.projection import Projector, SubspacePartitioning, transfer_cvs_to_full
 from adcc.HfCounterData import HfCounterData
 
@@ -215,7 +216,10 @@ class TestProjector(unittest.TestCase):
 test_cases = testcases.get_by_filename(
     "h2o_sto3g", "h2o_def2tzvp", "cn_sto3g", "cn_ccpvdz"
 )
-cases = [(case.file_name, kind) for case in test_cases for kind in case.kinds["pp"]]
+cases = [
+    (case.file_name, kind) for case in test_cases
+    for kind in case.kinds[AdcType.PP]
+]
 
 
 @pytest.mark.parametrize("system,kind", cases)

--- a/adcc/tests/testcases.py
+++ b/adcc/tests/testcases.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass, asdict, fields
 from pathlib import Path
 from typing import Optional
 
+from adcc.AdcMethod import AdcType
+
 
 # NOTE: Can't use a dict, because TestCase has to be hashable.
 @dataclass(frozen=True)
@@ -11,8 +13,8 @@ class Kinds:
     ip: tuple[str, ...] = tuple()
     ea: tuple[str, ...] = tuple()
 
-    def __getitem__(self, key: str):
-        return getattr(self, key)
+    def __getitem__(self, key: AdcType):
+        return getattr(self, key.to_str())
 
 
 @dataclass(frozen=True)
@@ -84,13 +86,13 @@ class TestCase:
             ret[key] = getattr(self, field)
         return ret
 
-    def filter_cases(self, adc_type: str) -> tuple[str, ...]:
+    def filter_cases(self, adc_type: AdcType) -> tuple[str, ...]:
         """
         Filter the available cases only returning cases that are relevant
         for the given adc_type.
         """
         # since cvs is not (yet) implemented for IP.
-        if adc_type == "pp":
+        if adc_type is AdcType.PP:
             return self.cases
         raise NotImplementedError(f"Filtering for adc type {adc_type} not "
                                   "implemented.")


### PR DESCRIPTION
Add triples ISR(2) contributions to the `state_diffdm` and add a new `2d` special level to explicitly exclude them. Also the generation of the default block orders of the `AdcMatrix` and the `IsrMatrix` has been generalized for n-particle operators. Moreover, `AdcType` and `GroundStateType` enums have been introduced on the `AdcMethod` class to handle IP/EA- and RE/REMP-ADC in the future