### PR TITLE
Add additional Psi4 integrals to the backend interface

### DIFF
--- a/adcc/backends/psi4.py
+++ b/adcc/backends/psi4.py
@@ -34,7 +34,8 @@ from ..OneParticleOperator import OneParticleOperator
 
 class Psi4OperatorIntegralProvider:
     available: tuple[str, ...] = (
-        "electric_dipole", "electric_dipole_velocity", "magnetic_dipole",
+        "overlap", "electric_dipole", "electric_dipole_velocity", "magnetic_dipole",
+        "electric_quadrupole", "electric_quadrupole_traceless",
         "pe_induction_elec", "pcm_potential_elec"
     )
 
@@ -42,6 +43,10 @@ class Psi4OperatorIntegralProvider:
         self.wfn = wfn
         self.backend = "psi4"
         self.mints = psi4.core.MintsHelper(self.wfn)
+
+    @property
+    def overlap(self) -> np.ndarray:
+        return np.asarray(self.mints.ao_overlap())
 
     @property
     def electric_dipole(self) -> tuple[np.ndarray, ...]:
@@ -69,6 +74,32 @@ class Psi4OperatorIntegralProvider:
         -sum_i p_i
         """
         return tuple(-1.0 * np.asarray(comp) for comp in self.mints.ao_nabla())
+
+    def electric_quadrupole(self, gauge_origin="origin") -> tuple[np.ndarray, ...]:
+        """-sum_i r_{i, alpha} r_{i, beta}"""
+        # TODO: Gauge origin?
+        if gauge_origin != (0.0, 0.0, 0.0) and gauge_origin != "origin":
+            raise NotImplementedError('Only (0.0, 0.0, 0.0) can be selected as'
+                                      ' gauge origin.')
+        # Expand 6 upper-triangular components to 9 symmetric matrix entries.
+        u = [np.asarray(comp) for comp in self.mints.ao_quadrupole()]
+        full = u[:3] + [u[1], u[3], u[4]] + [u[2], u[4], u[5]]
+        return tuple(full)
+
+    def electric_quadrupole_traceless(self, gauge_origin="origin"
+                                      ) -> tuple[np.ndarray, ...]:
+        """
+        -0.5 * sum_i (3 * r_{i, alpha} r_{i, beta}
+        - delta_{alpha, beta} r_{i}^2)
+        """
+        # TODO: Gauge origin?
+        if gauge_origin != (0.0, 0.0, 0.0) and gauge_origin != "origin":
+            raise NotImplementedError('Only (0.0, 0.0, 0.0) can be selected as'
+                                      ' gauge origin.')
+        # Expand 6 upper-triangular components to 9 symmetric matrix entries.
+        u = [np.asarray(comp) for comp in self.mints.ao_traceless_quadrupole()]
+        full = u[:3] + [u[1], u[3], u[4]] + [u[2], u[4], u[5]]
+        return tuple(full)
 
     def pe_induction_elec(self, dm: OneParticleOperator) -> psi4.core.Matrix:
         if not hasattr(self.wfn, "pe_state"):

--- a/adcc/backends/psi4.py
+++ b/adcc/backends/psi4.py
@@ -60,8 +60,11 @@ class Psi4OperatorIntegralProvider:
         """
         # TODO: Gauge origin?
         if gauge_origin != (0.0, 0.0, 0.0) and gauge_origin != "origin":
-            raise NotImplementedError('Only (0.0, 0.0, 0.0) can be selected as'
-                                      ' gauge origin.')
+            raise NotImplementedError(
+                "For Psi4 only the origin (0.0, 0.0, 0.0) can be selected as"
+                " gauge origin for the magnetic dipole operator. "
+                f"{gauge_origin} is not valid."
+            )
         return tuple(
             0.5 * np.asarray(comp)
             for comp in self.mints.ao_angular_momentum()
@@ -79,12 +82,15 @@ class Psi4OperatorIntegralProvider:
         """-sum_i r_{i, alpha} r_{i, beta}"""
         # TODO: Gauge origin?
         if gauge_origin != (0.0, 0.0, 0.0) and gauge_origin != "origin":
-            raise NotImplementedError('Only (0.0, 0.0, 0.0) can be selected as'
-                                      ' gauge origin.')
+            raise NotImplementedError(
+                "For Psi4 only the origin (0.0, 0.0, 0.0) can be selected as"
+                " gauge origin for the electric quadrupole operator. "
+                f"{gauge_origin} is not valid."
+            )
         # Expand 6 upper-triangular components to 9 symmetric matrix entries.
         u = [np.asarray(comp) for comp in self.mints.ao_quadrupole()]
-        full = u[:3] + [u[1], u[3], u[4]] + [u[2], u[4], u[5]]
-        return tuple(full)
+        assert len(u) == 6
+        return (u[0], u[1], u[2], u[1], u[3], u[4], u[2], u[4], u[5])
 
     def electric_quadrupole_traceless(self, gauge_origin="origin"
                                       ) -> tuple[np.ndarray, ...]:
@@ -94,12 +100,15 @@ class Psi4OperatorIntegralProvider:
         """
         # TODO: Gauge origin?
         if gauge_origin != (0.0, 0.0, 0.0) and gauge_origin != "origin":
-            raise NotImplementedError('Only (0.0, 0.0, 0.0) can be selected as'
-                                      ' gauge origin.')
+            raise NotImplementedError(
+                "For Psi4 only the origin (0.0, 0.0, 0.0) can be selected as"
+                " gauge origin for the traceless electric quadrupole operator. "
+                f"{gauge_origin} is not valid."
+            )
         # Expand 6 upper-triangular components to 9 symmetric matrix entries.
         u = [np.asarray(comp) for comp in self.mints.ao_traceless_quadrupole()]
-        full = u[:3] + [u[1], u[3], u[4]] + [u[2], u[4], u[5]]
-        return tuple(full)
+        assert len(u) == 6
+        return (u[0], u[1], u[2], u[1], u[3], u[4], u[2], u[4], u[5])
 
     def pe_induction_elec(self, dm: OneParticleOperator) -> psi4.core.Matrix:
         if not hasattr(self.wfn, "pe_state"):

--- a/adcc/tests/backends/backends_crossref_test.py
+++ b/adcc/tests/backends/backends_crossref_test.py
@@ -326,7 +326,7 @@ def compare_adc_results(adc_results, atol):
 
         if (
             not state1.reference_state.restricted
-            and set(state1.reference_state.mospaces.subspaces) == {"o1", "v1"}
+            and not state1.reference_state.has_core_occupied_space
         ):
             if "overlap" in state1.operators.available and \
                     "overlap" in state2.operators.available:

--- a/adcc/tests/backends/backends_crossref_test.py
+++ b/adcc/tests/backends/backends_crossref_test.py
@@ -244,7 +244,6 @@ def compare_adc_results(adc_results, atol):
             np.testing.assert_allclose(actual_mod, desired_mod)
 
         fixed_signs = None
-        fixed_signs_2d = None
         # test properties
         # the signs of the transition moments can differ between different ADC
         # calculations (due to the eigenvectors), but this should be uniform for
@@ -323,7 +322,7 @@ def compare_adc_results(adc_results, atol):
                 fixed_signs = fixed_signs_new
             else:
                 # sign is consistent across all matrix elements of a state.
-                assert_allclose_signs(fixed_signs_new[:,:,0], fixed_signs)
+                assert_allclose_signs(fixed_signs_new[:, :, 0], fixed_signs)
 
         if (
             not state1.reference_state.restricted
@@ -331,10 +330,7 @@ def compare_adc_results(adc_results, atol):
         ):
             if "overlap" in state1.operators.available and \
                     "overlap" in state2.operators.available:
-                assert_allclose(
-                        state1.state_ssq,
-                        state2.state_ssq,
-                        atol=atol)
+                assert_allclose(state1.state_ssq, state2.state_ssq, atol=atol)
 
         # Only in two backends the gauge origin selection is implemented.
         if len(set(comb) & set(backends_with_gauge_origin)) == 2:

--- a/adcc/tests/backends/backends_crossref_test.py
+++ b/adcc/tests/backends/backends_crossref_test.py
@@ -244,6 +244,7 @@ def compare_adc_results(adc_results, atol):
             np.testing.assert_allclose(actual_mod, desired_mod)
 
         fixed_signs = None
+        fixed_signs_2d = None
         # test properties
         # the signs of the transition moments can differ between different ADC
         # calculations (due to the eigenvectors), but this should be uniform for
@@ -305,6 +306,35 @@ def compare_adc_results(adc_results, atol):
                 fixed_signs = fixed_signs_new
             else:
                 assert_allclose_signs(fixed_signs_new, fixed_signs)
+
+        if "electric_quadrupole" in state1.operators.available and \
+                "electric_quadrupole" in state2.operators.available:
+            for i in range(len(state1.transition_quadrupole_moment("origin"))):
+                assert_allclose_signfix(
+                    state1.transition_quadrupole_moment("origin")[i],
+                    state2.transition_quadrupole_moment("origin")[i],
+                    atol=atol)
+            fixed_signs_new = fix_signs(
+                state1.transition_quadrupole_moment("origin"),
+                state2.transition_quadrupole_moment("origin"),
+                atol=atol
+            )
+            if fixed_signs is None:
+                fixed_signs = fixed_signs_new
+            else:
+                # sign is consistent across all matrix elements of a state.
+                assert_allclose_signs(fixed_signs_new[:,:,0], fixed_signs)
+
+        if (
+            not state1.reference_state.restricted
+            and set(state1.reference_state.mospaces.subspaces) == {"o1", "v1"}
+        ):
+            if "overlap" in state1.operators.available and \
+                    "overlap" in state2.operators.available:
+                assert_allclose(
+                        state1.state_ssq,
+                        state2.state_ssq,
+                        atol=atol)
 
         # Only in two backends the gauge origin selection is implemented.
         if len(set(comb) & set(backends_with_gauge_origin)) == 2:

--- a/adcc/tests/backends/psi4_test.py
+++ b/adcc/tests/backends/psi4_test.py
@@ -98,8 +98,9 @@ class TestPsi4:
             assert_almost_equal(eri_perm, eri)
 
     def operators_test(self, wfn):
-        # Test electric dipole
         mints = psi4.core.MintsHelper(wfn.basisset())
+
+        # Test electric dipole
         ao_dip = [np.array(comp) for comp in mints.ao_dipole()]
         operator_import_from_ao_test(wfn, ao_dip)
 
@@ -111,6 +112,19 @@ class TestPsi4:
         ao_dip = [-1.0 * np.array(comp) for comp in mints.ao_nabla()]
         operator_import_from_ao_test(wfn, ao_dip,
                                      operator="electric_dipole_velocity")
+
+        # Test electric quadrupole
+        u = [np.asarray(comp) for comp in mints.ao_quadrupole()]
+        # Expand 6 upper-triangular components to 9 symmetric matrix entries.
+        ao_quad = u[:3] + [u[1], u[3], u[4]] + [u[2], u[4], u[5]]
+        operator_import_from_ao_test(wfn, ao_quad, "electric_quadrupole")
+
+        # Test electric quadrupole traceless
+        u = [np.asarray(comp) for comp in mints.ao_traceless_quadrupole()]
+        # Expand 6 upper-triangular components to 9 symmetric matrix entries.
+        ao_quad_traceless = u[:3] + [u[1], u[3], u[4]] + [u[2], u[4], u[5]]
+        operator_import_from_ao_test(wfn, ao_quad_traceless,
+                                     "electric_quadrupole_traceless")
 
     @pytest.mark.parametrize("system", h2o, ids=[case.file_name for case in h2o])
     def test_rhf(self, system: testcases.TestCase):

--- a/adcc/tests/backends/pyscf_test.py
+++ b/adcc/tests/backends/pyscf_test.py
@@ -150,6 +150,38 @@ class TestPyscf:
                                          "electric_quadrupole_traceless",
                                          gauge_origin)
 
+            # Test electric quadrupole velocity
+            with mf.mol.with_common_orig(gauge_origin):
+                r_p = mf.mol.intor('int1e_irp', comp=9, hermi=0)
+                r_p = np.reshape(r_p, (3, 3, r_p.shape[1], r_p.shape[1]))
+                ovlp = mf.mol.intor_symmetric('int1e_ovlp', comp=1)
+                ovlp_matrix = np.zeros_like(r_p)
+                for i in range(3):
+                    ovlp_matrix[i][i] = ovlp
+                term = r_p + r_p.transpose(1, 0, 2, 3) - ovlp_matrix
+                ao_quad_vel = (
+                    -1.0 * np.reshape(term, (9, ovlp.shape[0], ovlp.shape[0]))
+                )
+            operator_import_from_ao_test(mf, list(ao_quad_vel),
+                                         "electric_quadrupole_velocity",
+                                         gauge_origin)
+
+            # Test diamagnetic magnetizability
+            with mf.mol.with_common_orig(gauge_origin):
+                r_r = mf.mol.intor_symmetric('int1e_rr', comp=9)
+                r_r = np.reshape(r_r, (3, 3, r_r.shape[1], r_r.shape[1]))
+                r_quadr = mf.mol.intor_symmetric('int1e_r2', comp=1)
+                r_quadr_matrix = np.zeros_like(r_r)
+                for i in range(3):
+                    r_quadr_matrix[i][i] = r_quadr
+                term = 0.25 * (r_quadr_matrix - r_r)
+                diag_mag = (
+                    np.reshape(term, (9, r_quadr.shape[0], r_quadr.shape[0]))
+                )
+            operator_import_from_ao_test(mf, list(diag_mag),
+                                         "diamagnetic_magnetizability",
+                                         gauge_origin)
+
     @pytest.mark.parametrize("system", h2o, ids=[case.file_name for case in h2o])
     def test_rhf(self, system: testcases.TestCase):
         mf = adcc.backends.run_hf("pyscf", system.xyz, system.basis)

--- a/adcc/tests/backends/pyscf_test.py
+++ b/adcc/tests/backends/pyscf_test.py
@@ -134,6 +134,22 @@ class TestPyscf:
             operator_import_from_ao_test(mf, list(ao_quad),
                                          "electric_quadrupole", gauge_origin)
 
+            # Test electric quadrupole traceless
+            with mf.mol.with_common_orig(gauge_origin):
+                r_r = mf.mol.intor_symmetric('int1e_rr', comp=9)
+                r_r = np.reshape(r_r, (3, 3, r_r.shape[1], r_r.shape[1]))
+                r_quadr = mf.mol.intor_symmetric('int1e_r2', comp=1)
+                r_quadr_matrix = np.zeros_like(r_r)
+                for i in range(3):
+                    r_quadr_matrix[i][i] = r_quadr
+                term = 0.5 * (3 * r_r - r_quadr_matrix)
+                ao_quad_traceless = (
+                    -1.0 * np.reshape(term, (9, r_quadr.shape[0], r_quadr.shape[0]))
+                )
+            operator_import_from_ao_test(mf, list(ao_quad_traceless),
+                                         "electric_quadrupole_traceless",
+                                         gauge_origin)
+
     @pytest.mark.parametrize("system", h2o, ids=[case.file_name for case in h2o])
     def test_rhf(self, system: testcases.TestCase):
         mf = adcc.backends.run_hf("pyscf", system.xyz, system.basis)

--- a/adcc/tests/backends/testing.py
+++ b/adcc/tests/backends/testing.py
@@ -154,7 +154,7 @@ def operator_import_from_ao_test(scfres, ao_dict, operator="electric_dipole",
 
     if operator in ["magnetic_dipole"]:
         int_imported = getattr(refstate.operators, operator)(gauge_origin)
-    elif operator in ["electric_quadrupole"]:
+    elif operator in ["electric_quadrupole", "electric_quadrupole_traceless"]:
         callback = getattr(refstate.operators, operator)(gauge_origin)
         # flatten the list of lists of OneParticleOperators
         int_imported = [quad for quads in callback for quad in quads]

--- a/adcc/tests/backends/testing.py
+++ b/adcc/tests/backends/testing.py
@@ -154,7 +154,10 @@ def operator_import_from_ao_test(scfres, ao_dict, operator="electric_dipole",
 
     if operator in ["magnetic_dipole"]:
         int_imported = getattr(refstate.operators, operator)(gauge_origin)
-    elif operator in ["electric_quadrupole", "electric_quadrupole_traceless"]:
+    elif operator in [
+        "electric_quadrupole", "electric_quadrupole_traceless",
+        "electric_quadrupole_velocity", "diamagnetic_magnetizability"
+    ]:
         callback = getattr(refstate.operators, operator)(gauge_origin)
         # flatten the list of lists of OneParticleOperators
         int_imported = [quad for quads in callback for quad in quads]


### PR DESCRIPTION
New integrals for the psi4 backend:
- overlap (needed for ssq)
- electric quadrupole
- electric quadrupole traceless
