### PR TITLE
Add geometry optimization scanner for gradients

### DIFF
--- a/adcc/__init__.py
+++ b/adcc/__init__.py
@@ -47,7 +47,9 @@ from .OneParticleDensity import OneParticleDensity
 from .TwoParticleOperator import TwoParticleOperator
 from .TwoParticleDensity import TwoParticleDensity
 from .opt_einsum_integration import register_with_opt_einsum
-from .gradients import nuclear_gradient
+from .gradients import (ExcitedStateTarget, GroundStateTarget,
+                        NuclearGradientScanner, nuclear_gradient,
+                        nuclear_gradient_scanner)
 
 # This has to be the last set of import
 from .guess import (guess_symmetries, guess_zero, guesses_any, guesses_singlet,
@@ -69,7 +71,8 @@ __all__ = ["run_adc", "InputError", "AdcMatrix",
            "guess_symmetries", "guesses_spin_flip", "guess_zero", "LazyMp",
            "adc0", "cis", "adc1", "adc2", "adc2x", "adc3",
            "cvs_adc0", "cvs_adc1", "cvs_adc2", "cvs_adc2x", "cvs_adc3",
-           "nuclear_gradient",
+           "nuclear_gradient", "nuclear_gradient_scanner",
+           "NuclearGradientScanner", "GroundStateTarget", "ExcitedStateTarget",
            "banner"]
 
 __version__ = "0.17.1"

--- a/adcc/gradients/__init__.py
+++ b/adcc/gradients/__init__.py
@@ -36,7 +36,7 @@ from .orbital_response import (
     orbital_response, orbital_response_rhs, energy_weighted_density_matrix
 )
 from .amplitude_response import amplitude_relaxed_densities
-from .scanner import (ExcitedStateTarget, GroundStateTarget,
+from .scanner import (ExcitedStateTarget, GroundStateTarget,  # noqa: F401
                       NuclearGradientScanner, density_overlap_score,
                       nuclear_gradient_scanner)
 

--- a/adcc/gradients/__init__.py
+++ b/adcc/gradients/__init__.py
@@ -36,9 +36,14 @@ from .orbital_response import (
     orbital_response, orbital_response_rhs, energy_weighted_density_matrix
 )
 from .amplitude_response import amplitude_relaxed_densities
-from .scanner import (ExcitedStateTarget, GroundStateTarget,  # noqa: F401
+from .scanner import (ExcitedStateTarget, GroundStateTarget,
                       NuclearGradientScanner, density_overlap_score,
                       nuclear_gradient_scanner)
+
+__all__ = [
+    "nuclear_gradient", "nuclear_gradient_scanner", "NuclearGradientScanner",
+    "GroundStateTarget", "ExcitedStateTarget", "density_overlap_score",
+]
 
 
 @dataclass(frozen=True)

--- a/adcc/gradients/__init__.py
+++ b/adcc/gradients/__init__.py
@@ -36,6 +36,9 @@ from .orbital_response import (
     orbital_response, orbital_response_rhs, energy_weighted_density_matrix
 )
 from .amplitude_response import amplitude_relaxed_densities
+from .scanner import (ExcitedStateTarget, GroundStateTarget,
+                      NuclearGradientScanner, density_overlap_score,
+                      nuclear_gradient_scanner)
 
 
 @dataclass(frozen=True)

--- a/adcc/gradients/scanner.py
+++ b/adcc/gradients/scanner.py
@@ -59,7 +59,6 @@ class ExcitedStateTarget:
         """Return keyword arguments forwarded to :func:`adcc.run_adc`."""
         ret = dict(self.run_adc_kwargs)
         ret["method"] = self.method
-        ret.setdefault("output", None)
         return ret
 
 
@@ -263,8 +262,11 @@ class NuclearGradientScanner:
         return excitations[best]
 
     def _descriptor(self, excitation, mol):
+        # PySCF SCF scanner objects mutate their internal Mole in-place between
+        # geometries.  Keep an independent copy for cross-overlap root tracking;
+        # otherwise the "previous" AO basis silently turns into the current one.
         return _TrackingDescriptor(
-            mol=mol,
+            mol=mol.copy(),
             transition_dm=_safe_ao_ndarray(excitation, "transition_dm_ao"),
             state_diffdm=_safe_ao_ndarray(excitation, "state_diffdm_ao"),
         )

--- a/adcc/gradients/scanner.py
+++ b/adcc/gradients/scanner.py
@@ -1,0 +1,503 @@
+#!/usr/bin/env python3
+## vi: tabstop=4 shiftwidth=4 softtabstop=4 expandtab
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2026 by the adcc authors
+##
+## This file is part of adcc.
+##
+## adcc is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published
+## by the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## adcc is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with adcc. If not, see <http://www.gnu.org/licenses/>.
+##
+## ---------------------------------------------------------------------
+"""Geometry-optimisation scanner for adcc nuclear gradients.
+
+The scanner owns the per-geometry PySCF -> adcc -> gradient loop.  It is
+intentionally PySCF-only for now, because the production direct nuclear-gradient
+path is PySCF-only as well.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional
+import warnings
+
+import numpy as np
+
+from adcc.Excitation import Excitation
+from adcc.LazyMp import LazyMp
+
+
+@dataclass(frozen=True)
+class GroundStateTarget:
+    """Ground-state MP target for a nuclear-gradient scanner."""
+
+    level: int = 2
+
+
+@dataclass(frozen=True)
+class ExcitedStateTarget:
+    """Excited-state ADC target for a nuclear-gradient scanner."""
+
+    method: str
+    state_index: int = 0
+    n_states: Optional[int] = None
+    kind: str = "any"
+    n_singlets: Optional[int] = None
+    n_triplets: Optional[int] = None
+    n_spin_flip: Optional[int] = None
+    core_orbitals: Any = None
+    frozen_core: Any = None
+    frozen_virtual: Any = None
+    conv_tol: Optional[float] = None
+    environment: Any = None
+    solverargs: dict[str, Any] = field(default_factory=dict)
+
+    def run_adc_kwargs(self) -> dict[str, Any]:
+        """Return keyword arguments forwarded to :func:`adcc.run_adc`."""
+        ret = {
+            "method": self.method,
+            "n_states": self.n_states,
+            "kind": self.kind,
+            "n_singlets": self.n_singlets,
+            "n_triplets": self.n_triplets,
+            "n_spin_flip": self.n_spin_flip,
+            "core_orbitals": self.core_orbitals,
+            "frozen_core": self.frozen_core,
+            "frozen_virtual": self.frozen_virtual,
+            "conv_tol": self.conv_tol,
+            "environment": self.environment,
+            "output": None,
+        }
+        ret.update(self.solverargs)
+        return {key: value for key, value in ret.items() if value is not None}
+
+
+@dataclass
+class TrackingResult:
+    """Diagnostic information for the most recent root-tracking decision."""
+
+    index: int
+    scores: np.ndarray
+
+
+@dataclass
+class _TrackingDescriptor:
+    mol: Any
+    transition_dm: Optional[np.ndarray]
+    state_diffdm: Optional[np.ndarray]
+
+
+@dataclass
+class _ScfSettings:
+    conv_tol: float
+    conv_tol_grad: Optional[float]
+    max_cycle: int
+    verbose: int
+    attributes: dict[str, Any]
+
+
+class NuclearGradientScanner:
+    """Callable scanner returning adcc energies and nuclear gradients.
+
+    Parameters are usually created through :func:`nuclear_gradient_scanner`.
+    The scanner accepts Cartesian coordinates in Bohr and returns an energy in
+    Hartree and a gradient in Hartree/Bohr.
+    """
+
+    def __init__(self, mol_template=None, *, scf_template=None,
+                 scf_factory: Optional[Callable[[Any], Any]] = None,
+                 target: GroundStateTarget | ExcitedStateTarget | str | None = None,
+                 method: Optional[str] = None, state_index: int = 0,
+                 mp_level: int = 2, n_states: Optional[int] = None,
+                 kind: str = "any", n_singlets: Optional[int] = None,
+                 n_triplets: Optional[int] = None,
+                 n_spin_flip: Optional[int] = None, core_orbitals: Any = None,
+                 frozen_core: Any = None, frozen_virtual: Any = None,
+                 adc_conv_tol: Optional[float] = None, environment: Any = None,
+                 scf_type: Optional[str] = None, scf_conv_tol: Optional[float] = None,
+                 scf_conv_tol_grad: Optional[float] = None,
+                 scf_max_cycle: Optional[int] = None, symmetry: Any = None,
+                 verbose: Optional[int] = None, follow: str = "overlap",
+                 tracking_min_score: float = 0.0, tracking_min_gap: float = 0.0,
+                 gradient_kwargs: Optional[dict[str, Any]] = None,
+                 adc_solverargs: Optional[dict[str, Any]] = None):
+        self._pyscf = _import_pyscf()
+        self.scf_factory = scf_factory
+        self.scf_type = scf_type
+        self._requested_symmetry = symmetry
+        self.follow = follow
+        self.tracking_min_score = tracking_min_score
+        self.tracking_min_gap = tracking_min_gap
+        self.gradient_kwargs = dict(gradient_kwargs or {})
+        self.last_tracking: Optional[TrackingResult] = None
+
+        if scf_template is None and _is_pyscf_scf(self._pyscf, mol_template):
+            scf_template = mol_template
+            mol_template = scf_template.mol
+        if scf_template is not None and mol_template is None:
+            mol_template = scf_template.mol
+        if mol_template is None:
+            raise ValueError("mol_template or scf_template needs to be provided.")
+
+        self._init_mol_template(mol_template)
+        self.scf_class = type(scf_template) if scf_template is not None else None
+        self.scf_settings = self._capture_scf_settings(
+            scf_template, scf_conv_tol, scf_conv_tol_grad, scf_max_cycle, verbose
+        )
+        self.target = self._normalise_target(
+            target, method, state_index, mp_level, n_states, kind, n_singlets,
+            n_triplets, n_spin_flip, core_orbitals, frozen_core, frozen_virtual,
+            adc_conv_tol, environment, adc_solverargs or {}
+        )
+
+        self.previous_scf = None
+        self.previous_dm = None
+        self.previous_states = None
+        self.previous_excitation: Optional[Excitation] = None
+        self.previous_descriptor: Optional[_TrackingDescriptor] = None
+        self.last_scf = None
+        self.last_states = None
+        self.last_excitation = None
+        self.last_gradient = None
+
+    @property
+    def natoms(self) -> int:
+        return len(self.atom_symbols)
+
+    def __call__(self, coords):
+        """Return ``(energy, gradient)`` for Cartesian coordinates in Bohr."""
+        coords = self._coords_array(coords)
+        scfres = self._run_scf(coords)
+        target = self._build_target(scfres)
+
+        from adcc.gradients import nuclear_gradient
+        grad = nuclear_gradient(target, **self.gradient_kwargs)
+        if isinstance(target, LazyMp):
+            energy = target.energy(self.target.level)
+        else:
+            energy = target.total_energy
+
+        self.last_scf = scfres
+        self.last_gradient = grad
+        self.previous_scf = scfres
+        self.previous_dm = scfres.make_rdm1()
+        if isinstance(target, Excitation):
+            self.previous_states = self.last_states
+            self.previous_excitation = target
+            self.previous_descriptor = self._descriptor(target, scfres.mol)
+        return float(energy), np.asarray(grad.total)
+
+    def calc_new(self, coords):
+        """geomeTRIC custom-engine entry point.
+
+        ``coords`` is a flattened Cartesian coordinate array in Bohr.  The
+        returned gradient is flattened in Hartree/Bohr.
+        """
+        energy, gradient = self(coords)
+        return {"energy": energy, "gradient": np.asarray(gradient).ravel()}
+
+    def _init_mol_template(self, mol):
+        self.atom_symbols = [mol.atom_symbol(i) for i in range(mol.natm)]
+        self.basis = mol.basis
+        self.ecp = getattr(mol, "ecp", None)
+        self.charge = mol.charge
+        self.spin = mol.spin
+        self.cart = bool(getattr(mol, "cart", False))
+        self.symmetry = (getattr(mol, "symmetry", False)
+                         if self._requested_symmetry is None
+                         else self._requested_symmetry)
+        self.output = getattr(mol, "output", None)
+        self.max_memory = getattr(mol, "max_memory", None)
+        self.initial_coords = np.asarray(mol.atom_coords(unit="Bohr"), dtype=float)
+
+    def _capture_scf_settings(self, scf_template, conv_tol, conv_tol_grad,
+                              max_cycle, verbose):
+        attributes = {}
+        if scf_template is not None:
+            for attr in [
+                "diis_space", "diis_start_cycle", "damp", "level_shift",
+                "direct_scf", "init_guess", "max_memory",
+            ]:
+                if hasattr(scf_template, attr):
+                    attributes[attr] = getattr(scf_template, attr)
+            default_conv_tol = scf_template.conv_tol
+            default_conv_tol_grad = getattr(scf_template, "conv_tol_grad", None)
+            default_max_cycle = scf_template.max_cycle
+            default_verbose = scf_template.verbose
+        else:
+            default_conv_tol = 1e-11
+            default_conv_tol_grad = 1e-9
+            default_max_cycle = 150
+            default_verbose = 0
+        return _ScfSettings(
+            conv_tol=default_conv_tol if conv_tol is None else conv_tol,
+            conv_tol_grad=(default_conv_tol_grad if conv_tol_grad is None
+                           else conv_tol_grad),
+            max_cycle=default_max_cycle if max_cycle is None else max_cycle,
+            verbose=default_verbose if verbose is None else verbose,
+            attributes=attributes,
+        )
+
+    def _normalise_target(self, target, method, state_index, mp_level, n_states,
+                          kind, n_singlets, n_triplets, n_spin_flip,
+                          core_orbitals, frozen_core, frozen_virtual,
+                          adc_conv_tol, environment, solverargs):
+        if isinstance(target, (GroundStateTarget, ExcitedStateTarget)):
+            return target
+        if isinstance(target, str):
+            if target.lower().startswith("mp"):
+                try:
+                    level = int(target.lower().removeprefix("mp"))
+                except ValueError:
+                    level = mp_level
+                return GroundStateTarget(level=level)
+            method = target
+        if method is None or method.lower().startswith("mp"):
+            if method and method.lower().startswith("mp"):
+                try:
+                    mp_level = int(method.lower().removeprefix("mp"))
+                except ValueError:
+                    pass
+            return GroundStateTarget(level=mp_level)
+        return ExcitedStateTarget(
+            method=method, state_index=state_index, n_states=n_states, kind=kind,
+            n_singlets=n_singlets, n_triplets=n_triplets,
+            n_spin_flip=n_spin_flip, core_orbitals=core_orbitals,
+            frozen_core=frozen_core, frozen_virtual=frozen_virtual,
+            conv_tol=adc_conv_tol, environment=environment,
+            solverargs=dict(solverargs),
+        )
+
+    def _coords_array(self, coords):
+        coords = np.asarray(coords, dtype=float)
+        if coords.shape == (3 * self.natoms,):
+            coords = coords.reshape(self.natoms, 3)
+        if coords.shape != (self.natoms, 3):
+            raise ValueError(
+                f"Expected coordinates with shape {(self.natoms, 3)} or "
+                f"{(3 * self.natoms,)}, got {coords.shape}."
+            )
+        return coords
+
+    def _build_mol(self, coords):
+        gto = self._pyscf.gto
+        atom = [(sym, tuple(map(float, xyz)))
+                for sym, xyz in zip(self.atom_symbols, coords)]
+        kwargs = {
+            "atom": atom,
+            "basis": self.basis,
+            "unit": "Bohr",
+            "spin": self.spin,
+            "charge": self.charge,
+            "symmetry": self.symmetry,
+            "parse_arg": False,
+            "dump_input": False,
+            "verbose": self.scf_settings.verbose,
+            "cart": self.cart,
+        }
+        if self.ecp:
+            kwargs["ecp"] = self.ecp
+        mol = gto.M(**kwargs)
+        if self.max_memory is not None:
+            mol.max_memory = self.max_memory
+        return mol
+
+    def _build_scf(self, mol):
+        scf = self._pyscf.scf
+        if self.scf_factory is not None:
+            mf = self.scf_factory(mol)
+        elif self.scf_class is not None:
+            mf = self.scf_class(mol)
+        elif self.scf_type is not None:
+            scf_type = self.scf_type.upper()
+            if not hasattr(scf, scf_type):
+                raise ValueError(f"Unknown PySCF SCF type '{self.scf_type}'.")
+            mf = getattr(scf, scf_type)(mol)
+        else:
+            mf = scf.HF(mol)
+        mf.conv_tol = self.scf_settings.conv_tol
+        if self.scf_settings.conv_tol_grad is not None:
+            mf.conv_tol_grad = self.scf_settings.conv_tol_grad
+        mf.max_cycle = self.scf_settings.max_cycle
+        mf.verbose = self.scf_settings.verbose
+        for attr, value in self.scf_settings.attributes.items():
+            if hasattr(mf, attr):
+                setattr(mf, attr, value)
+        return mf
+
+    def _run_scf(self, coords):
+        mol = self._build_mol(coords)
+        mf = self._build_scf(mol)
+        if self.previous_dm is None:
+            mf.kernel()
+        else:
+            mf.kernel(dm0=self.previous_dm)
+        if not mf.converged:
+            raise RuntimeError("PySCF SCF did not converge at scanner geometry.")
+        return mf
+
+    def _build_target(self, scfres):
+        if isinstance(self.target, GroundStateTarget):
+            from adcc import LazyMp, ReferenceState
+            return LazyMp(ReferenceState(scfres))
+        from adcc import run_adc
+        states = run_adc(scfres, **self.target.run_adc_kwargs())
+        self.last_states = states
+        excitation = self._select_excitation(states, scfres.mol)
+        self.last_excitation = excitation
+        return excitation
+
+    def _select_excitation(self, states, mol):
+        excitations = states.excitations
+        if not excitations:
+            raise RuntimeError("ADC calculation did not return any excited states.")
+        if self.follow == "index" or self.previous_descriptor is None:
+            index = self.target.state_index
+            if index >= len(excitations) or index < -len(excitations):
+                raise ValueError(
+                    f"state_index {index} is out of range for "
+                    f"{len(excitations)} computed states."
+                )
+            self.last_tracking = None
+            return excitations[index]
+        if self.follow != "overlap":
+            raise ValueError("follow needs to be 'overlap' or 'index'.")
+        scores = np.array([
+            self._tracking_score(self.previous_descriptor,
+                                 self._descriptor(excitation, mol), mol)
+            for excitation in excitations
+        ])
+        order = np.argsort(scores)[::-1]
+        best = int(order[0])
+        self.last_tracking = TrackingResult(best, scores)
+        if scores[best] < self.tracking_min_score:
+            raise RuntimeError(
+                "Root tracking failed: best state-character overlap "
+                f"{scores[best]:.6g} is below threshold "
+                f"{self.tracking_min_score:.6g}."
+            )
+        if len(order) > 1 and scores[best] - scores[int(order[1])] < self.tracking_min_gap:
+            raise RuntimeError(
+                "Root tracking is ambiguous: best and second-best overlaps "
+                f"differ by {scores[best] - scores[int(order[1])]:.6g}."
+            )
+        return excitations[best]
+
+    def _descriptor(self, excitation, mol):
+        return _TrackingDescriptor(
+            mol=mol,
+            transition_dm=_safe_ao_ndarray(excitation, "transition_dm_ao"),
+            state_diffdm=_safe_ao_ndarray(excitation, "state_diffdm_ao"),
+        )
+
+    def _tracking_score(self, previous, current, current_mol):
+        s_cross = self._pyscf.gto.intor_cross(
+            "int1e_ovlp", previous.mol, current_mol
+        )
+        score = 0.0
+        weight = 0
+        for old, new, use_abs in [
+            (previous.transition_dm, current.transition_dm, True),
+            (previous.state_diffdm, current.state_diffdm, False),
+        ]:
+            if old is None or new is None:
+                continue
+            channel = density_overlap_score(
+                old, new, s_cross,
+                s_old=previous.mol.intor_symmetric("int1e_ovlp"),
+                s_new=current_mol.intor_symmetric("int1e_ovlp"),
+                use_abs=use_abs,
+            )
+            if np.isfinite(channel):
+                score += channel
+                weight += 1
+        if weight == 0:
+            raise RuntimeError(
+                "Root tracking requested, but neither transition_dm_ao nor "
+                "state_diffdm_ao could be computed."
+            )
+        return score / weight
+
+
+def nuclear_gradient_scanner(*args, **kwargs) -> NuclearGradientScanner:
+    """Create a PySCF/adcc nuclear-gradient scanner.
+
+    See :class:`NuclearGradientScanner` for the coordinate and unit contract.
+    """
+    return NuclearGradientScanner(*args, **kwargs)
+
+
+def density_overlap_score(old_dm, new_dm, s_cross, *, s_old=None, s_new=None,
+                          use_abs=False) -> float:
+    """Cosine-like overlap of AO-basis density matrices at two geometries.
+
+    ``s_cross`` is the rectangular AO overlap between the old and new PySCF
+    molecules, i.e. ``pyscf.gto.intor_cross('int1e_ovlp', old_mol, new_mol)``.
+    ``s_old`` and ``s_new`` are the AO overlap matrices within each geometry.
+    They default to identity matrices for simple unit tests.
+    """
+    old_dm = np.asarray(old_dm)
+    new_dm = np.asarray(new_dm)
+    s_cross = np.asarray(s_cross)
+    if s_old is None:
+        s_old = np.eye(old_dm.shape[0])
+    if s_new is None:
+        s_new = np.eye(new_dm.shape[0])
+    s_old = np.asarray(s_old)
+    s_new = np.asarray(s_new)
+    numerator = np.einsum("pq,pr,rs,qs->", old_dm, s_cross, new_dm, s_cross)
+    old_norm = np.einsum("pq,pr,rs,qs->", old_dm, s_old, old_dm, s_old)
+    new_norm = np.einsum("pq,pr,rs,qs->", new_dm, s_new, new_dm, s_new)
+    denom = np.sqrt(abs(old_norm) * abs(new_norm))
+    if denom == 0.0:
+        return np.nan
+    score = numerator / denom
+    if use_abs:
+        score = abs(score)
+    return float(score)
+
+
+def _safe_ao_ndarray(excitation, attr):
+    try:
+        value = getattr(excitation, attr)
+        return value.to_ndarray()
+    except Exception as exc:  # pragma: no cover - exercised by optional paths
+        warnings.warn(
+            f"Could not compute {attr} for root tracking: {exc}",
+            RuntimeWarning,
+        )
+        return None
+
+
+def _import_pyscf():
+    try:
+        from pyscf import gto, scf
+    except ImportError as exc:  # pragma: no cover - depends on optional dep
+        raise ModuleNotFoundError(
+            "nuclear_gradient_scanner currently requires PySCF. Install PySCF "
+            "or pass a PySCF template object in an environment where PySCF is "
+            "available."
+        ) from exc
+    return _PyscfModules(gto=gto, scf=scf)
+
+
+@dataclass(frozen=True)
+class _PyscfModules:
+    gto: Any
+    scf: Any
+
+
+def _is_pyscf_scf(pyscf, obj) -> bool:
+    return isinstance(obj, pyscf.scf.hf.SCF)

--- a/adcc/gradients/scanner.py
+++ b/adcc/gradients/scanner.py
@@ -68,6 +68,11 @@ class TrackingResult:
 
     index: int
     scores: np.ndarray
+    best_score: float = 0.0
+    gap: float = float("inf")
+    previous_index: Optional[int] = None
+    switched: bool = False
+    unavailable_channels: tuple[str, ...] = ()
 
 
 @dataclass
@@ -101,7 +106,9 @@ class NuclearGradientScanner:
                 "scf.RHF(mol), as its first argument."
             )
         if not hasattr(scfres, "as_scanner"):
-            raise TypeError("The provided PySCF SCF object has no as_scanner method.")
+            raise TypeError(
+                "The provided PySCF SCF object has no as_scanner method."
+            )
 
         self.scf_template = scfres
         self.scf_scanner = scfres.as_scanner()
@@ -113,6 +120,8 @@ class NuclearGradientScanner:
         )
 
         self.follow = follow
+        if self.follow not in ("overlap", "index"):
+            raise ValueError("follow needs to be 'overlap' or 'index'.")
         self.tracking_min_score = tracking_min_score
         self.tracking_min_gap = tracking_min_gap
         self.gradient_kwargs = dict(gradient_kwargs or {})
@@ -121,9 +130,8 @@ class NuclearGradientScanner:
         )
 
         self.previous_scf = None
-        self.previous_states = None
-        self.previous_excitation: Optional[Excitation] = None
         self.previous_descriptor: Optional[_TrackingDescriptor] = None
+        self.previous_index: Optional[int] = None
         self.last_scf = None
         self.last_states = None
         self.last_excitation = None
@@ -151,9 +159,11 @@ class NuclearGradientScanner:
         self.last_gradient = grad
         self.previous_scf = scfres
         if isinstance(target, Excitation):
-            self.previous_states = self.last_states
-            self.previous_excitation = target
             self.previous_descriptor = self._descriptor(target, scfres.mol)
+            if self.last_tracking is not None:
+                self.previous_index = self.last_tracking.index
+            else:
+                self.previous_index = self.target.state_index
         return float(energy), np.asarray(grad.total)
 
     def calc_new(self, coords):
@@ -168,10 +178,10 @@ class NuclearGradientScanner:
     def _normalise_target(self, target, method, state_index, mp_level,
                           run_adc_kwargs):
         if isinstance(target, (GroundStateTarget, ExcitedStateTarget)):
+            if isinstance(target, GroundStateTarget):
+                _check_ground_state_level(target.level)
             return target
         if isinstance(target, str):
-            if target.lower().startswith("mp"):
-                return GroundStateTarget(level=_mp_level(target, mp_level))
             method = target
         if method is None or method.lower().startswith("mp"):
             if method is not None:
@@ -181,6 +191,7 @@ class NuclearGradientScanner:
                     "Ignoring run_adc keyword arguments for ground-state MP "
                     "scanner target.", RuntimeWarning,
                 )
+            _check_ground_state_level(mp_level)
             return GroundStateTarget(level=mp_level)
         return ExcitedStateTarget(
             method=method, state_index=state_index,
@@ -216,7 +227,7 @@ class NuclearGradientScanner:
 
     def _build_target(self, scfres):
         if isinstance(self.target, GroundStateTarget):
-            from adcc import LazyMp, ReferenceState
+            from adcc import ReferenceState
             return LazyMp(ReferenceState(scfres))
         from adcc import run_adc
         states = run_adc(scfres, **self.target.kwargs())
@@ -238,26 +249,38 @@ class NuclearGradientScanner:
                 )
             self.last_tracking = None
             return excitations[index]
-        if self.follow != "overlap":
-            raise ValueError("follow needs to be 'overlap' or 'index'.")
+        unavailable: set[str] = set()
         scores = np.array([
             self._tracking_score(self.previous_descriptor,
-                                 self._descriptor(excitation, mol), mol)
+                                 self._descriptor(excitation, mol), mol,
+                                 unavailable)
             for excitation in excitations
         ])
         order = np.argsort(scores)[::-1]
         best = int(order[0])
-        self.last_tracking = TrackingResult(best, scores)
+        gap = (scores[best] - scores[int(order[1])]
+               if len(order) > 1 else float("inf"))
+        # Always record a diagnostic so silent state switching is observable on
+        # every call via ``last_tracking`` (best score, gap to second-best and
+        # whether the followed positional index changed).
+        switched = (self.previous_index is not None
+                    and best != self.previous_index)
+        self.last_tracking = TrackingResult(
+            index=best, scores=scores, best_score=float(scores[best]),
+            gap=float(gap), previous_index=self.previous_index,
+            switched=bool(switched),
+            unavailable_channels=tuple(sorted(unavailable)),
+        )
         if scores[best] < self.tracking_min_score:
             raise RuntimeError(
                 "Root tracking failed: best state-character overlap "
                 f"{scores[best]:.6g} is below threshold "
                 f"{self.tracking_min_score:.6g}."
             )
-        if len(order) > 1 and scores[best] - scores[int(order[1])] < self.tracking_min_gap:
+        if len(order) > 1 and gap < self.tracking_min_gap:
             raise RuntimeError(
                 "Root tracking is ambiguous: best and second-best overlaps "
-                f"differ by {scores[best] - scores[int(order[1])]:.6g}."
+                f"differ by {gap:.6g}."
             )
         return excitations[best]
 
@@ -271,23 +294,26 @@ class NuclearGradientScanner:
             state_diffdm=_safe_ao_ndarray(excitation, "state_diffdm_ao"),
         )
 
-    def _tracking_score(self, previous, current, current_mol):
+    def _tracking_score(self, previous, current, current_mol, unavailable=None):
         s_cross = self._pyscf.gto.intor_cross(
             "int1e_ovlp", previous.mol, current_mol
         )
+        s_old = previous.mol.intor_symmetric("int1e_ovlp")
+        s_new = current_mol.intor_symmetric("int1e_ovlp")
         score = 0.0
         weight = 0
-        for old, new, use_abs in [
-            (previous.transition_dm, current.transition_dm, True),
-            (previous.state_diffdm, current.state_diffdm, False),
+        for name, old, new, use_abs in [
+            ("transition_dm_ao", previous.transition_dm,
+             current.transition_dm, True),
+            ("state_diffdm_ao", previous.state_diffdm,
+             current.state_diffdm, False),
         ]:
             if old is None or new is None:
+                if unavailable is not None:
+                    unavailable.add(name)
                 continue
             channel = density_overlap_score(
-                old, new, s_cross,
-                s_old=previous.mol.intor_symmetric("int1e_ovlp"),
-                s_new=current_mol.intor_symmetric("int1e_ovlp"),
-                use_abs=use_abs,
+                old, new, s_cross, s_old=s_old, s_new=s_new, use_abs=use_abs,
             )
             if np.isfinite(channel):
                 score += channel
@@ -344,12 +370,22 @@ def _safe_ao_ndarray(excitation, attr):
     try:
         value = getattr(excitation, attr)
         return value.to_ndarray()
-    except Exception as exc:  # pragma: no cover - exercised by optional paths
-        warnings.warn(
-            f"Could not compute {attr} for root tracking: {exc}",
-            RuntimeWarning,
-        )
+    except (AttributeError, NotImplementedError):
+        # The operator/attribute is genuinely unavailable for this method.  The
+        # degradation is recorded per call on ``last_tracking`` (see
+        # ``_tracking_score``), so it stays observable on every call rather than
+        # being deduplicated by Python's warning filter.  Any other exception
+        # signals a real bug and is allowed to propagate.
         return None
+
+
+def _check_ground_state_level(level):
+    if level != 2:
+        raise NotImplementedError(
+            "adcc only provides MP2 ground-state nuclear gradients, so the "
+            f"scanner cannot pair an MP{level} energy with an MP2 gradient. "
+            "Use level=2 for a ground-state MP target."
+        )
 
 
 def _mp_level(method, default):

--- a/adcc/gradients/scanner.py
+++ b/adcc/gradients/scanner.py
@@ -22,15 +22,16 @@
 ## ---------------------------------------------------------------------
 """Geometry-optimisation scanner for adcc nuclear gradients.
 
-The scanner owns the per-geometry PySCF -> adcc -> gradient loop.  It is
-intentionally PySCF-only for now, because the production direct nuclear-gradient
-path is PySCF-only as well.
+The scanner owns the per-geometry PySCF -> adcc -> gradient loop.  Users pass a
+configured PySCF SCF object, whose settings define how SCF is performed at every
+geometry.  adcc-specific keyword arguments are forwarded unchanged to
+:func:`adcc.run_adc` for excited-state targets.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional
+from typing import Any, Optional
 import warnings
 
 import numpy as np
@@ -52,36 +53,14 @@ class ExcitedStateTarget:
 
     method: str
     state_index: int = 0
-    n_states: Optional[int] = None
-    kind: str = "any"
-    n_singlets: Optional[int] = None
-    n_triplets: Optional[int] = None
-    n_spin_flip: Optional[int] = None
-    core_orbitals: Any = None
-    frozen_core: Any = None
-    frozen_virtual: Any = None
-    conv_tol: Optional[float] = None
-    environment: Any = None
-    solverargs: dict[str, Any] = field(default_factory=dict)
+    run_adc_kwargs: dict[str, Any] = field(default_factory=dict)
 
-    def run_adc_kwargs(self) -> dict[str, Any]:
+    def kwargs(self) -> dict[str, Any]:
         """Return keyword arguments forwarded to :func:`adcc.run_adc`."""
-        ret = {
-            "method": self.method,
-            "n_states": self.n_states,
-            "kind": self.kind,
-            "n_singlets": self.n_singlets,
-            "n_triplets": self.n_triplets,
-            "n_spin_flip": self.n_spin_flip,
-            "core_orbitals": self.core_orbitals,
-            "frozen_core": self.frozen_core,
-            "frozen_virtual": self.frozen_virtual,
-            "conv_tol": self.conv_tol,
-            "environment": self.environment,
-            "output": None,
-        }
-        ret.update(self.solverargs)
-        return {key: value for key, value in ret.items() if value is not None}
+        ret = dict(self.run_adc_kwargs)
+        ret["method"] = self.method
+        ret.setdefault("output", None)
+        return ret
 
 
 @dataclass
@@ -99,71 +78,50 @@ class _TrackingDescriptor:
     state_diffdm: Optional[np.ndarray]
 
 
-@dataclass
-class _ScfSettings:
-    conv_tol: float
-    conv_tol_grad: Optional[float]
-    max_cycle: int
-    verbose: int
-    attributes: dict[str, Any]
-
-
 class NuclearGradientScanner:
     """Callable scanner returning adcc energies and nuclear gradients.
 
     Parameters are usually created through :func:`nuclear_gradient_scanner`.
-    The scanner accepts Cartesian coordinates in Bohr and returns an energy in
-    Hartree and a gradient in Hartree/Bohr.
+    ``scfres`` is a configured PySCF SCF object.  Its molecule and SCF settings
+    are used as the template for every scanner call; only the nuclear geometry
+    changes.  Coordinates are Cartesian in Bohr, energies are Hartree and
+    gradients are Hartree/Bohr.
     """
 
-    def __init__(self, mol_template=None, *, scf_template=None,
-                 scf_factory: Optional[Callable[[Any], Any]] = None,
+    def __init__(self, scfres, *,
                  target: GroundStateTarget | ExcitedStateTarget | str | None = None,
                  method: Optional[str] = None, state_index: int = 0,
-                 mp_level: int = 2, n_states: Optional[int] = None,
-                 kind: str = "any", n_singlets: Optional[int] = None,
-                 n_triplets: Optional[int] = None,
-                 n_spin_flip: Optional[int] = None, core_orbitals: Any = None,
-                 frozen_core: Any = None, frozen_virtual: Any = None,
-                 adc_conv_tol: Optional[float] = None, environment: Any = None,
-                 scf_type: Optional[str] = None, scf_conv_tol: Optional[float] = None,
-                 scf_conv_tol_grad: Optional[float] = None,
-                 scf_max_cycle: Optional[int] = None, symmetry: Any = None,
-                 verbose: Optional[int] = None, follow: str = "overlap",
+                 mp_level: int = 2, follow: str = "overlap",
                  tracking_min_score: float = 0.0, tracking_min_gap: float = 0.0,
                  gradient_kwargs: Optional[dict[str, Any]] = None,
-                 adc_solverargs: Optional[dict[str, Any]] = None):
+                 **run_adc_kwargs):
         self._pyscf = _import_pyscf()
-        self.scf_factory = scf_factory
-        self.scf_type = scf_type
-        self._requested_symmetry = symmetry
+        if not _is_pyscf_scf(self._pyscf, scfres):
+            raise TypeError(
+                "nuclear_gradient_scanner expects a PySCF SCF object, e.g. "
+                "scf.RHF(mol), as its first argument."
+            )
+        if not hasattr(scfres, "as_scanner"):
+            raise TypeError("The provided PySCF SCF object has no as_scanner method.")
+
+        self.scf_template = scfres
+        self.scf_scanner = scfres.as_scanner()
+        self.base_mol = scfres.mol.copy()
+        self.atom_symbols = [self.base_mol.atom_symbol(i)
+                             for i in range(self.base_mol.natm)]
+        self.initial_coords = np.asarray(
+            self.base_mol.atom_coords(unit="Bohr"), dtype=float
+        )
+
         self.follow = follow
         self.tracking_min_score = tracking_min_score
         self.tracking_min_gap = tracking_min_gap
         self.gradient_kwargs = dict(gradient_kwargs or {})
-        self.last_tracking: Optional[TrackingResult] = None
-
-        if scf_template is None and _is_pyscf_scf(self._pyscf, mol_template):
-            scf_template = mol_template
-            mol_template = scf_template.mol
-        if scf_template is not None and mol_template is None:
-            mol_template = scf_template.mol
-        if mol_template is None:
-            raise ValueError("mol_template or scf_template needs to be provided.")
-
-        self._init_mol_template(mol_template)
-        self.scf_class = type(scf_template) if scf_template is not None else None
-        self.scf_settings = self._capture_scf_settings(
-            scf_template, scf_conv_tol, scf_conv_tol_grad, scf_max_cycle, verbose
-        )
         self.target = self._normalise_target(
-            target, method, state_index, mp_level, n_states, kind, n_singlets,
-            n_triplets, n_spin_flip, core_orbitals, frozen_core, frozen_virtual,
-            adc_conv_tol, environment, adc_solverargs or {}
+            target, method, state_index, mp_level, run_adc_kwargs
         )
 
         self.previous_scf = None
-        self.previous_dm = None
         self.previous_states = None
         self.previous_excitation: Optional[Excitation] = None
         self.previous_descriptor: Optional[_TrackingDescriptor] = None
@@ -171,6 +129,7 @@ class NuclearGradientScanner:
         self.last_states = None
         self.last_excitation = None
         self.last_gradient = None
+        self.last_tracking: Optional[TrackingResult] = None
 
     @property
     def natoms(self) -> int:
@@ -192,7 +151,6 @@ class NuclearGradientScanner:
         self.last_scf = scfres
         self.last_gradient = grad
         self.previous_scf = scfres
-        self.previous_dm = scfres.make_rdm1()
         if isinstance(target, Excitation):
             self.previous_states = self.last_states
             self.previous_excitation = target
@@ -208,76 +166,26 @@ class NuclearGradientScanner:
         energy, gradient = self(coords)
         return {"energy": energy, "gradient": np.asarray(gradient).ravel()}
 
-    def _init_mol_template(self, mol):
-        self.atom_symbols = [mol.atom_symbol(i) for i in range(mol.natm)]
-        self.basis = mol.basis
-        self.ecp = getattr(mol, "ecp", None)
-        self.charge = mol.charge
-        self.spin = mol.spin
-        self.cart = bool(getattr(mol, "cart", False))
-        self.symmetry = (getattr(mol, "symmetry", False)
-                         if self._requested_symmetry is None
-                         else self._requested_symmetry)
-        self.output = getattr(mol, "output", None)
-        self.max_memory = getattr(mol, "max_memory", None)
-        self.initial_coords = np.asarray(mol.atom_coords(unit="Bohr"), dtype=float)
-
-    def _capture_scf_settings(self, scf_template, conv_tol, conv_tol_grad,
-                              max_cycle, verbose):
-        attributes = {}
-        if scf_template is not None:
-            for attr in [
-                "diis_space", "diis_start_cycle", "damp", "level_shift",
-                "direct_scf", "init_guess", "max_memory",
-            ]:
-                if hasattr(scf_template, attr):
-                    attributes[attr] = getattr(scf_template, attr)
-            default_conv_tol = scf_template.conv_tol
-            default_conv_tol_grad = getattr(scf_template, "conv_tol_grad", None)
-            default_max_cycle = scf_template.max_cycle
-            default_verbose = scf_template.verbose
-        else:
-            default_conv_tol = 1e-11
-            default_conv_tol_grad = 1e-9
-            default_max_cycle = 150
-            default_verbose = 0
-        return _ScfSettings(
-            conv_tol=default_conv_tol if conv_tol is None else conv_tol,
-            conv_tol_grad=(default_conv_tol_grad if conv_tol_grad is None
-                           else conv_tol_grad),
-            max_cycle=default_max_cycle if max_cycle is None else max_cycle,
-            verbose=default_verbose if verbose is None else verbose,
-            attributes=attributes,
-        )
-
-    def _normalise_target(self, target, method, state_index, mp_level, n_states,
-                          kind, n_singlets, n_triplets, n_spin_flip,
-                          core_orbitals, frozen_core, frozen_virtual,
-                          adc_conv_tol, environment, solverargs):
+    def _normalise_target(self, target, method, state_index, mp_level,
+                          run_adc_kwargs):
         if isinstance(target, (GroundStateTarget, ExcitedStateTarget)):
             return target
         if isinstance(target, str):
             if target.lower().startswith("mp"):
-                try:
-                    level = int(target.lower().removeprefix("mp"))
-                except ValueError:
-                    level = mp_level
-                return GroundStateTarget(level=level)
+                return GroundStateTarget(level=_mp_level(target, mp_level))
             method = target
         if method is None or method.lower().startswith("mp"):
-            if method and method.lower().startswith("mp"):
-                try:
-                    mp_level = int(method.lower().removeprefix("mp"))
-                except ValueError:
-                    pass
+            if method is not None:
+                mp_level = _mp_level(method, mp_level)
+            if run_adc_kwargs:
+                warnings.warn(
+                    "Ignoring run_adc keyword arguments for ground-state MP "
+                    "scanner target.", RuntimeWarning,
+                )
             return GroundStateTarget(level=mp_level)
         return ExcitedStateTarget(
-            method=method, state_index=state_index, n_states=n_states, kind=kind,
-            n_singlets=n_singlets, n_triplets=n_triplets,
-            n_spin_flip=n_spin_flip, core_orbitals=core_orbitals,
-            frozen_core=frozen_core, frozen_virtual=frozen_virtual,
-            conv_tol=adc_conv_tol, environment=environment,
-            solverargs=dict(solverargs),
+            method=method, state_index=state_index,
+            run_adc_kwargs=dict(run_adc_kwargs),
         )
 
     def _coords_array(self, coords):
@@ -291,69 +199,28 @@ class NuclearGradientScanner:
             )
         return coords
 
-    def _build_mol(self, coords):
-        gto = self._pyscf.gto
-        atom = [(sym, tuple(map(float, xyz)))
-                for sym, xyz in zip(self.atom_symbols, coords)]
-        kwargs = {
-            "atom": atom,
-            "basis": self.basis,
-            "unit": "Bohr",
-            "spin": self.spin,
-            "charge": self.charge,
-            "symmetry": self.symmetry,
-            "parse_arg": False,
-            "dump_input": False,
-            "verbose": self.scf_settings.verbose,
-            "cart": self.cart,
-        }
-        if self.ecp:
-            kwargs["ecp"] = self.ecp
-        mol = gto.M(**kwargs)
-        if self.max_memory is not None:
-            mol.max_memory = self.max_memory
-        return mol
-
-    def _build_scf(self, mol):
-        scf = self._pyscf.scf
-        if self.scf_factory is not None:
-            mf = self.scf_factory(mol)
-        elif self.scf_class is not None:
-            mf = self.scf_class(mol)
-        elif self.scf_type is not None:
-            scf_type = self.scf_type.upper()
-            if not hasattr(scf, scf_type):
-                raise ValueError(f"Unknown PySCF SCF type '{self.scf_type}'.")
-            mf = getattr(scf, scf_type)(mol)
-        else:
-            mf = scf.HF(mol)
-        mf.conv_tol = self.scf_settings.conv_tol
-        if self.scf_settings.conv_tol_grad is not None:
-            mf.conv_tol_grad = self.scf_settings.conv_tol_grad
-        mf.max_cycle = self.scf_settings.max_cycle
-        mf.verbose = self.scf_settings.verbose
-        for attr, value in self.scf_settings.attributes.items():
-            if hasattr(mf, attr):
-                setattr(mf, attr, value)
-        return mf
+    def _mol_at(self, coords):
+        # PySCF's set_geom_ preserves the original Mole settings (basis, charge,
+        # spin, symmetry setting, unit conventions, etc.) and changes only atom
+        # coordinates.  This keeps the scanner interface anchored on the user's
+        # configured PySCF object rather than mirroring PySCF keyword arguments.
+        return self.base_mol.set_geom_(coords, unit="Bohr", inplace=False)
 
     def _run_scf(self, coords):
-        mol = self._build_mol(coords)
-        mf = self._build_scf(mol)
-        if self.previous_dm is None:
-            mf.kernel()
-        else:
-            mf.kernel(dm0=self.previous_dm)
-        if not mf.converged:
+        mol = self._mol_at(coords)
+        self.scf_scanner(mol)
+        if not self.scf_scanner.converged:
             raise RuntimeError("PySCF SCF did not converge at scanner geometry.")
-        return mf
+        # Snapshot the current scanner state for adcc.  The scanner itself is
+        # reused on the next geometry to keep PySCF's orbital/density continuity.
+        return self.scf_scanner.undo_scanner()
 
     def _build_target(self, scfres):
         if isinstance(self.target, GroundStateTarget):
             from adcc import LazyMp, ReferenceState
             return LazyMp(ReferenceState(scfres))
         from adcc import run_adc
-        states = run_adc(scfres, **self.target.run_adc_kwargs())
+        states = run_adc(scfres, **self.target.kwargs())
         self.last_states = states
         excitation = self._select_excitation(states, scfres.mol)
         self.last_excitation = excitation
@@ -434,7 +301,9 @@ class NuclearGradientScanner:
 def nuclear_gradient_scanner(*args, **kwargs) -> NuclearGradientScanner:
     """Create a PySCF/adcc nuclear-gradient scanner.
 
-    See :class:`NuclearGradientScanner` for the coordinate and unit contract.
+    The first argument is a configured PySCF SCF object.  Keyword arguments not
+    consumed by the scanner are forwarded unchanged to :func:`adcc.run_adc` for
+    excited-state targets.
     """
     return NuclearGradientScanner(*args, **kwargs)
 
@@ -481,14 +350,20 @@ def _safe_ao_ndarray(excitation, attr):
         return None
 
 
+def _mp_level(method, default):
+    try:
+        return int(method.lower().removeprefix("mp"))
+    except ValueError:
+        return default
+
+
 def _import_pyscf():
     try:
         from pyscf import gto, scf
     except ImportError as exc:  # pragma: no cover - depends on optional dep
         raise ModuleNotFoundError(
             "nuclear_gradient_scanner currently requires PySCF. Install PySCF "
-            "or pass a PySCF template object in an environment where PySCF is "
-            "available."
+            "and pass a configured PySCF SCF object."
         ) from exc
     return _PyscfModules(gto=gto, scf=scf)
 

--- a/adcc/tests/functionality_geomopt_test.py
+++ b/adcc/tests/functionality_geomopt_test.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+## vi: tabstop=4 shiftwidth=4 softtabstop=4 expandtab
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2026 by the adcc authors
+##
+## This file is part of adcc.
+##
+## adcc is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published
+## by the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## adcc is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with adcc. If not, see <http://www.gnu.org/licenses/>.
+##
+## ---------------------------------------------------------------------
+"""End-to-end geometry-optimisation smoke tests.
+
+These drive the :func:`adcc.nuclear_gradient_scanner` through geomeTRIC (via
+PySCF's geomopt bridge) and are skipped cleanly when either optional dependency
+is unavailable.
+"""
+import importlib.util
+
+import numpy as np
+import pytest
+
+import adcc
+import adcc.backends
+
+
+def _missing(*modules):
+    return [m for m in modules if importlib.util.find_spec(m) is None]
+
+
+_required = ["pyscf", "geometric"]
+pytestmark = pytest.mark.skipif(
+    "pyscf" not in adcc.backends.available() or _missing(*_required),
+    reason="PySCF and geomeTRIC are required for end-to-end geomopt tests.",
+)
+
+
+def _h2o_scf():
+    from pyscf import gto, scf
+    mol = gto.M(
+        atom="""
+        O 0 0 0
+        H 0 0 1.795239827225189
+        H 1.693194615993441 0 -0.599043184453037
+        """,
+        basis="sto-3g", unit="Bohr", symmetry=False,
+        verbose=0, parse_arg=False,
+    )
+    mf = scf.RHF(mol)
+    mf.conv_tol = 1e-11
+    mf.conv_tol_grad = 1e-9
+    return mf
+
+
+def test_ground_state_optimization_reaches_stationary_point():
+    from pyscf.geomopt import as_pyscf_method, geometric_solver
+
+    scfres = _h2o_scf()
+    scanner = adcc.nuclear_gradient_scanner(scfres, method="mp2")
+
+    def energy_and_gradient(mol_at_step):
+        return scanner(mol_at_step.atom_coords(unit="Bohr"))
+
+    method = as_pyscf_method(scfres.mol, energy_and_gradient)
+    mol_eq = geometric_solver.optimize(
+        method, maxsteps=50,
+        convergence_grms=1e-4, convergence_gmax=2e-4,
+    )
+
+    # The gradient at the optimised geometry must be (near) zero.
+    _, gradient = scanner(mol_eq.atom_coords(unit="Bohr"))
+    gmax = np.abs(gradient).max()
+    assert gmax < 5e-4
+
+
+def test_calc_new_drives_geometric_internal_engine():
+    # Exercise the geomeTRIC custom-engine calc_new contract directly: flattened
+    # Bohr coordinates in, energy plus flattened Hartree/Bohr gradient out.
+    scanner = adcc.nuclear_gradient_scanner(_h2o_scf(), method="mp2")
+    result = scanner.calc_new(scanner.initial_coords.ravel())
+    assert set(result) == {"energy", "gradient"}
+    assert np.isfinite(result["energy"])
+    assert result["gradient"].shape == (3 * scanner.natoms,)

--- a/adcc/tests/functionality_geomopt_test.py
+++ b/adcc/tests/functionality_geomopt_test.py
@@ -92,3 +92,36 @@ def test_calc_new_drives_geometric_internal_engine():
     assert set(result) == {"energy", "gradient"}
     assert np.isfinite(result["energy"])
     assert result["gradient"].shape == (3 * scanner.natoms,)
+
+
+def test_excited_state_optimization_tracks_state_across_steps():
+    from pyscf.geomopt import as_pyscf_method, geometric_solver
+
+    scfres = _h2o_scf()
+    scanner = adcc.nuclear_gradient_scanner(
+        scfres, method="adc2", n_singlets=3, state_index=0,
+        follow="overlap", conv_tol=1e-8,
+        gradient_kwargs={"eri_contraction": "full_ao"},
+    )
+
+    seen_energies = []
+
+    def energy_and_gradient(mol_at_step):
+        energy, gradient = scanner(mol_at_step.atom_coords(unit="Bohr"))
+        seen_energies.append(scanner.last_excitation.excitation_energy)
+        return energy, gradient
+
+    method = as_pyscf_method(scfres.mol, energy_and_gradient)
+
+    # The optimisation does not need to fully converge here; a few steps are
+    # enough to exercise root tracking across geometries.
+    geometric_solver.optimize(
+        method, maxsteps=3,
+        convergence_grms=1e-4, convergence_gmax=2e-4,
+    )
+
+    # Multiple scanner calls were made and state tracking stayed active.
+    assert len(seen_energies) >= 2
+    assert scanner.last_tracking is not None
+    # The followed excitation energy must stay finite and positive every step.
+    assert all(np.isfinite(omega) and omega > 0.0 for omega in seen_energies)

--- a/adcc/tests/geomopt_scanner_test.py
+++ b/adcc/tests/geomopt_scanner_test.py
@@ -122,3 +122,118 @@ def test_tracking_descriptor_keeps_independent_mol_snapshot():
     mol.set_geom_(old_coords + 0.1, unit="Bohr")
 
     assert_allclose(descriptor.mol.atom_coords(unit="Bohr"), old_coords)
+
+
+def test_unconverged_scf_raises():
+    from pyscf import scf
+    mf = scf.RHF(_h2o_scf().mol)
+    mf.max_cycle = 1
+    mf.conv_tol = 1e-12
+    mf.conv_tol_grad = 1e-10
+    scanner = adcc.nuclear_gradient_scanner(mf, method="mp2")
+    with pytest.raises(RuntimeError, match="did not converge"):
+        scanner(scanner.initial_coords)
+
+
+def test_excited_state_scanner_matches_explicit_gradient_loop():
+    scanner = adcc.nuclear_gradient_scanner(
+        _h2o_scf(), method="adc2", n_singlets=3, state_index=0,
+        follow="index", conv_tol=1e-9,
+        gradient_kwargs={"eri_contraction": "full_ao"},
+    )
+
+    energy, gradient = scanner(scanner.initial_coords)
+
+    # Fixed-index selection must pick exactly the requested positional state.
+    assert scanner.last_excitation.index == 0
+    assert scanner.last_tracking is None
+
+    states = adcc.run_adc(scanner.last_scf, method="adc2", n_singlets=3,
+                          conv_tol=1e-9)
+    explicit = adcc.nuclear_gradient(states.excitations[0],
+                                     eri_contraction="full_ao")
+    assert energy == pytest.approx(states.excitations[0].total_energy, abs=1e-7)
+    assert gradient.shape == (3, 3)
+    assert_allclose(gradient, explicit.total, atol=1e-7)
+
+
+def test_overlap_tracking_follows_same_state_character():
+    scanner = adcc.nuclear_gradient_scanner(
+        _h2o_scf(), method="adc2", n_singlets=3, state_index=1,
+        follow="overlap", conv_tol=1e-9,
+        gradient_kwargs={"eri_contraction": "full_ao"},
+    )
+
+    # First call seeds the tracker from the positional index.
+    scanner(scanner.initial_coords)
+    assert scanner.last_excitation.index == 1
+    assert scanner.last_tracking is None
+
+    # Second call at the same geometry must follow the seeded state via density
+    # overlap.  At identical geometry the matching state has self-overlap ~1.
+    scanner(scanner.initial_coords)
+    assert scanner.last_tracking is not None
+    assert scanner.last_tracking.index == 1
+    scores = scanner.last_tracking.scores
+    assert np.argmax(scores) == 1
+    assert scores[1] == pytest.approx(1.0, abs=1e-3)
+
+
+def test_overlap_tracking_continuous_under_small_displacement():
+    scanner = adcc.nuclear_gradient_scanner(
+        _h2o_scf(), method="adc2", n_singlets=3, state_index=0,
+        follow="overlap", conv_tol=1e-9,
+        gradient_kwargs={"eri_contraction": "full_ao"},
+    )
+
+    scanner(scanner.initial_coords)
+    omega_initial = scanner.last_excitation.excitation_energy
+
+    displaced = scanner.initial_coords.copy()
+    displaced[0, 2] += 0.02
+    scanner(displaced)
+
+    # The followed state should remain the same physical state, i.e. its
+    # excitation energy must not jump discontinuously between candidates.
+    assert scanner.last_tracking is not None
+    assert abs(scanner.last_excitation.excitation_energy - omega_initial) < 0.05
+
+
+def test_overlap_tracking_below_min_score_raises():
+    scanner = adcc.nuclear_gradient_scanner(
+        _h2o_scf(), method="adc2", n_singlets=3, state_index=0,
+        follow="overlap", tracking_min_score=2.0, conv_tol=1e-9,
+        gradient_kwargs={"eri_contraction": "full_ao"},
+    )
+    scanner(scanner.initial_coords)  # seed
+    with pytest.raises(RuntimeError, match="below threshold"):
+        scanner(scanner.initial_coords)
+
+
+def test_overlap_tracking_ambiguous_gap_raises():
+    scanner = adcc.nuclear_gradient_scanner(
+        _h2o_scf(), method="adc2", n_singlets=3, state_index=0,
+        follow="overlap", tracking_min_gap=10.0, conv_tol=1e-9,
+        gradient_kwargs={"eri_contraction": "full_ao"},
+    )
+    scanner(scanner.initial_coords)  # seed
+    with pytest.raises(RuntimeError, match="ambiguous"):
+        scanner(scanner.initial_coords)
+
+
+def test_scf_guess_continuity_updates_previous_state():
+    scanner = adcc.nuclear_gradient_scanner(
+        _h2o_scf(), method="mp2", gradient_kwargs={"eri_contraction": "full_ao"},
+    )
+
+    energy_first, _ = scanner(scanner.initial_coords)
+    assert scanner.previous_scf is scanner.last_scf
+
+    # Move away and return: the scanner reuses one PySCF scanner object across
+    # geometries (orbital/guess continuity), and the surface stays consistent so
+    # the energy at the original geometry is reproduced.
+    displaced = scanner.initial_coords.copy()
+    displaced[0, 2] += 0.05
+    scanner(displaced)
+    energy_back, _ = scanner(scanner.initial_coords)
+    assert energy_back == pytest.approx(energy_first, abs=1e-9)

--- a/adcc/tests/geomopt_scanner_test.py
+++ b/adcc/tests/geomopt_scanner_test.py
@@ -20,13 +20,20 @@
 ## along with adcc. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## ---------------------------------------------------------------------
+import types
+
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
 import adcc
 import adcc.backends
-from adcc.gradients.scanner import density_overlap_score
+from adcc.gradients.scanner import (
+    GroundStateTarget,
+    _TrackingDescriptor,
+    _safe_ao_ndarray,
+    density_overlap_score,
+)
 
 
 pytestmark = pytest.mark.skipif(
@@ -237,3 +244,175 @@ def test_scf_guess_continuity_updates_previous_state():
     scanner(displaced)
     energy_back, _ = scanner(scanner.initial_coords)
     assert energy_back == pytest.approx(energy_first, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Root-reorder tracking (FINDING 4)
+# ---------------------------------------------------------------------------
+
+class _FakeAoOperator:
+    def __init__(self, matrix):
+        self._matrix = matrix
+
+    def to_ndarray(self):
+        return self._matrix
+
+
+class _FakeExcitation:
+    def __init__(self, index, transition_dm, state_diffdm):
+        self.index = index
+        self.transition_dm_ao = _FakeAoOperator(transition_dm)
+        self.state_diffdm_ao = _FakeAoOperator(state_diffdm)
+
+
+def test_overlap_tracking_follows_reordered_root_by_overlap():
+    # Prove that overlap tracking follows a physical state whose *positional*
+    # index differs from the originally requested ``state_index``: the seeded
+    # descriptor matches candidate #1, while the requested state_index is 0.
+    scanner = adcc.nuclear_gradient_scanner(
+        _h2o_scf(), method="adc2", n_singlets=3, state_index=0,
+        follow="overlap",
+    )
+    nao = scanner.base_mol.nao
+
+    def projector(i):
+        m = np.zeros((nao, nao))
+        m[i, i] = 1.0
+        return m
+
+    # The previously-followed physical state has this character.
+    seed_transition = projector(0)
+    seed_diffdm = projector(1)
+    scanner.previous_descriptor = _TrackingDescriptor(
+        mol=scanner.base_mol.copy(),
+        transition_dm=seed_transition, state_diffdm=seed_diffdm,
+    )
+    scanner.previous_index = 0
+
+    # Candidate roots: index 1 carries the seeded character (energy ordering
+    # swapped so it is no longer at positional index 0).
+    candidates = [
+        _FakeExcitation(0, projector(2), projector(3)),
+        _FakeExcitation(1, seed_transition.copy(), seed_diffdm.copy()),
+        _FakeExcitation(2, projector(4), projector(5)),
+    ]
+    states = types.SimpleNamespace(excitations=candidates)
+
+    selected = scanner._select_excitation(states, scanner.base_mol.copy())
+
+    # Tracking must pick the reordered root (positional index 1) by overlap,
+    # which differs from the requested state_index (0).
+    assert selected.index == 1
+    assert scanner.target.state_index == 0
+    assert scanner.last_tracking is not None
+    assert scanner.last_tracking.index == 1
+    assert scanner.last_tracking.index != scanner.target.state_index
+    assert np.argmax(scanner.last_tracking.scores) == 1
+    # New diagnostic fields are populated and observable on every call.
+    assert scanner.last_tracking.best_score == pytest.approx(1.0)
+    assert scanner.last_tracking.gap > 0.0
+    assert np.isfinite(scanner.last_tracking.gap)
+    assert scanner.last_tracking.previous_index == 0
+    assert scanner.last_tracking.switched is True
+
+
+# ---------------------------------------------------------------------------
+# Validation / construction-time branches (FINDING 10)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("kwargs", [
+    {"target": "mp3"},
+    {"method": "mp3"},
+    {"target": GroundStateTarget(level=3)},
+])
+def test_ground_state_level_other_than_two_is_rejected(kwargs):
+    with pytest.raises(NotImplementedError, match="MP2 ground-state"):
+        adcc.nuclear_gradient_scanner(_h2o_scf(), **kwargs)
+
+
+def test_invalid_follow_raises_eagerly_at_construction():
+    with pytest.raises(ValueError, match="overlap.*index"):
+        adcc.nuclear_gradient_scanner(
+            _h2o_scf(), method="adc2", n_singlets=2, follow="bogus",
+        )
+
+
+def test_state_index_out_of_range_raises():
+    scanner = adcc.nuclear_gradient_scanner(
+        _h2o_scf(), method="adc2", n_singlets=2, state_index=5,
+        follow="index", conv_tol=1e-9,
+        gradient_kwargs={"eri_contraction": "full_ao"},
+    )
+    with pytest.raises(ValueError, match="out of range"):
+        scanner(scanner.initial_coords)
+
+
+def test_empty_excitations_raises_runtime_error():
+    scanner = adcc.nuclear_gradient_scanner(_h2o_scf(), method="adc2")
+    states = types.SimpleNamespace(excitations=[])
+    with pytest.raises(RuntimeError, match="did not return any excited states"):
+        scanner._select_excitation(states, scanner.base_mol.copy())
+
+
+@pytest.mark.parametrize("kwargs", [
+    {"method": "mp2", "n_singlets": 3},
+    {"target": "mp2", "n_singlets": 3},
+])
+def test_ground_state_run_adc_kwargs_emit_runtime_warning(kwargs):
+    with pytest.warns(RuntimeWarning, match="Ignoring run_adc"):
+        adcc.nuclear_gradient_scanner(_h2o_scf(), **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Density-overlap scoring branches (FINDING 10)
+# ---------------------------------------------------------------------------
+
+def test_safe_ao_ndarray_swallows_unavailable_channels():
+    class FailingOperator:
+        def to_ndarray(self):
+            raise NotImplementedError("not available")
+
+    class Excitation:
+        transition_dm_ao = FailingOperator()
+
+        @property
+        def state_diffdm_ao(self):
+            raise AttributeError("no diffdm")
+
+    excitation = Excitation()
+    assert _safe_ao_ndarray(excitation, "transition_dm_ao") is None
+    assert _safe_ao_ndarray(excitation, "state_diffdm_ao") is None
+
+
+def test_tracking_score_records_unavailable_and_raises_when_both_missing():
+    scanner = adcc.nuclear_gradient_scanner(_h2o_scf(), method="adc2")
+    mol = scanner.base_mol.copy()
+    previous = _TrackingDescriptor(mol=mol.copy(),
+                                   transition_dm=None, state_diffdm=None)
+    current = _TrackingDescriptor(mol=mol.copy(),
+                                  transition_dm=None, state_diffdm=None)
+    unavailable = set()
+    with pytest.raises(RuntimeError, match="neither transition_dm_ao"):
+        scanner._tracking_score(previous, current, mol, unavailable)
+    # Both channels are surfaced as unavailable before the weight==0 failure.
+    assert unavailable == {"transition_dm_ao", "state_diffdm_ao"}
+
+
+def test_density_overlap_score_zero_density_returns_nan():
+    zero = np.zeros((2, 2))
+    s = np.eye(2)
+    assert np.isnan(density_overlap_score(zero, np.eye(2), s))
+
+
+def test_density_overlap_score_nonidentity_metrics_matches_hand_value():
+    old = np.array([[1.0, 0.0], [0.0, 0.0]])
+    new = np.array([[1.0, 0.0], [0.0, 0.0]])
+    s_cross = np.array([[0.9, 0.1], [0.1, 0.9]])
+    s_old = np.array([[1.0, 0.2], [0.2, 1.0]])
+    s_new = np.array([[1.0, 0.3], [0.3, 1.0]])
+
+    # numerator = (D_old . s_cross . D_new . s_cross), norms use s_old/s_new.
+    # With single populated diagonal element: numerator = s_cross[0,0]**2 = 0.81,
+    # old_norm = s_old[0,0]**2 = 1.0, new_norm = s_new[0,0]**2 = 1.0.
+    score = density_overlap_score(old, new, s_cross, s_old=s_old, s_new=s_new)
+    assert score == pytest.approx(0.81)

--- a/adcc/tests/geomopt_scanner_test.py
+++ b/adcc/tests/geomopt_scanner_test.py
@@ -34,16 +34,21 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def _h2o_mol():
-    from pyscf import gto
-    return gto.M(
+def _h2o_scf():
+    from pyscf import gto, scf
+    mol = gto.M(
         atom="""
         O 0 0 0
         H 0 0 1.795239827225189
         H 1.693194615993441 0 -0.599043184453037
         """,
-        basis="sto-3g", unit="Bohr", verbose=0, parse_arg=False,
+        basis="sto-3g", unit="Bohr", symmetry=False,
+        verbose=0, parse_arg=False,
     )
+    mf = scf.RHF(mol)
+    mf.conv_tol = 1e-11
+    mf.conv_tol_grad = 1e-9
+    return mf
 
 
 def test_density_overlap_score_uses_absolute_transition_phase():
@@ -54,16 +59,20 @@ def test_density_overlap_score_uses_absolute_transition_phase():
     assert density_overlap_score(dm, -dm, s, use_abs=True) == pytest.approx(1.0)
 
 
+def test_scanner_requires_pyscf_scf_object():
+    with pytest.raises(TypeError, match="PySCF SCF object"):
+        adcc.nuclear_gradient_scanner(_h2o_scf().mol, method="mp2")
+
+
 def test_scanner_validates_coordinate_shape():
-    scanner = adcc.nuclear_gradient_scanner(_h2o_mol(), method="mp2")
+    scanner = adcc.nuclear_gradient_scanner(_h2o_scf(), method="mp2")
     with pytest.raises(ValueError, match="Expected coordinates"):
         scanner(np.zeros((2, 3)))
 
 
 def test_ground_state_scanner_matches_explicit_gradient_loop():
     scanner = adcc.nuclear_gradient_scanner(
-        _h2o_mol(), method="mp2", scf_conv_tol=1e-11,
-        scf_conv_tol_grad=1e-9, gradient_kwargs={"eri_contraction": "full_ao"},
+        _h2o_scf(), method="mp2", gradient_kwargs={"eri_contraction": "full_ao"},
     )
     coords = scanner.initial_coords
 
@@ -78,10 +87,18 @@ def test_ground_state_scanner_matches_explicit_gradient_loop():
 
 def test_calc_new_returns_geometric_engine_shape():
     scanner = adcc.nuclear_gradient_scanner(
-        _h2o_mol(), method="mp2", scf_conv_tol=1e-11,
-        scf_conv_tol_grad=1e-9, gradient_kwargs={"eri_contraction": "full_ao"},
+        _h2o_scf(), method="mp2", gradient_kwargs={"eri_contraction": "full_ao"},
     )
     result = scanner.calc_new(scanner.initial_coords.ravel())
     assert set(result) == {"energy", "gradient"}
     assert isinstance(result["energy"], float)
     assert result["gradient"].shape == (9,)
+
+
+def test_run_adc_kwargs_are_forwarded_with_native_names():
+    scanner = adcc.nuclear_gradient_scanner(
+        _h2o_scf(), method="adc2", n_singlets=2, conv_tol=1e-7,
+        follow="index", gradient_kwargs={"eri_contraction": "full_ao"},
+    )
+    assert scanner.target.kwargs()["conv_tol"] == pytest.approx(1e-7)
+    assert scanner.target.kwargs()["n_singlets"] == 2

--- a/adcc/tests/geomopt_scanner_test.py
+++ b/adcc/tests/geomopt_scanner_test.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+## vi: tabstop=4 shiftwidth=4 softtabstop=4 expandtab
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2026 by the adcc authors
+##
+## This file is part of adcc.
+##
+## adcc is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published
+## by the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## adcc is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with adcc. If not, see <http://www.gnu.org/licenses/>.
+##
+## ---------------------------------------------------------------------
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+import adcc
+import adcc.backends
+from adcc.gradients.scanner import density_overlap_score
+
+
+pytestmark = pytest.mark.skipif(
+    "pyscf" not in adcc.backends.available(), reason="PySCF not found."
+)
+
+
+def _h2o_mol():
+    from pyscf import gto
+    return gto.M(
+        atom="""
+        O 0 0 0
+        H 0 0 1.795239827225189
+        H 1.693194615993441 0 -0.599043184453037
+        """,
+        basis="sto-3g", unit="Bohr", verbose=0, parse_arg=False,
+    )
+
+
+def test_density_overlap_score_uses_absolute_transition_phase():
+    dm = np.eye(2)
+    s = np.eye(2)
+    assert density_overlap_score(dm, dm, s) == pytest.approx(1.0)
+    assert density_overlap_score(dm, -dm, s) == pytest.approx(-1.0)
+    assert density_overlap_score(dm, -dm, s, use_abs=True) == pytest.approx(1.0)
+
+
+def test_scanner_validates_coordinate_shape():
+    scanner = adcc.nuclear_gradient_scanner(_h2o_mol(), method="mp2")
+    with pytest.raises(ValueError, match="Expected coordinates"):
+        scanner(np.zeros((2, 3)))
+
+
+def test_ground_state_scanner_matches_explicit_gradient_loop():
+    scanner = adcc.nuclear_gradient_scanner(
+        _h2o_mol(), method="mp2", scf_conv_tol=1e-11,
+        scf_conv_tol_grad=1e-9, gradient_kwargs={"eri_contraction": "full_ao"},
+    )
+    coords = scanner.initial_coords
+
+    energy, gradient = scanner(coords)
+
+    mp = adcc.LazyMp(adcc.ReferenceState(scanner.last_scf))
+    explicit_gradient = adcc.nuclear_gradient(mp, eri_contraction="full_ao")
+    assert energy == pytest.approx(mp.energy(2))
+    assert gradient.shape == (3, 3)
+    assert_allclose(gradient, explicit_gradient.total)
+
+
+def test_calc_new_returns_geometric_engine_shape():
+    scanner = adcc.nuclear_gradient_scanner(
+        _h2o_mol(), method="mp2", scf_conv_tol=1e-11,
+        scf_conv_tol_grad=1e-9, gradient_kwargs={"eri_contraction": "full_ao"},
+    )
+    result = scanner.calc_new(scanner.initial_coords.ravel())
+    assert set(result) == {"energy", "gradient"}
+    assert isinstance(result["energy"], float)
+    assert result["gradient"].shape == (9,)

--- a/adcc/tests/geomopt_scanner_test.py
+++ b/adcc/tests/geomopt_scanner_test.py
@@ -102,3 +102,23 @@ def test_run_adc_kwargs_are_forwarded_with_native_names():
     )
     assert scanner.target.kwargs()["conv_tol"] == pytest.approx(1e-7)
     assert scanner.target.kwargs()["n_singlets"] == 2
+    assert "output" not in scanner.target.kwargs()
+
+
+def test_tracking_descriptor_keeps_independent_mol_snapshot():
+    class FakeAoOperator:
+        def to_ndarray(self):
+            return np.eye(7)
+
+    class FakeExcitation:
+        transition_dm_ao = FakeAoOperator()
+        state_diffdm_ao = FakeAoOperator()
+
+    scanner = adcc.nuclear_gradient_scanner(_h2o_scf(), method="adc2")
+    mol = scanner.base_mol.copy()
+    descriptor = scanner._descriptor(FakeExcitation(), mol)
+    old_coords = descriptor.mol.atom_coords(unit="Bohr").copy()
+
+    mol.set_geom_(old_coords + 0.1, unit="Bohr")
+
+    assert_allclose(descriptor.mol.atom_coords(unit="Bohr"), old_coords)

--- a/docs/gradients.rst
+++ b/docs/gradients.rst
@@ -46,6 +46,50 @@ instead:
 The returned object exposes the total gradient via ``grad.total`` as well as
 the individual one- and two-electron contributions.
 
+Geometry optimisation scanners
+------------------------------
+
+For geometry optimisers it is useful to expose the whole PySCF/adcc/gradient
+loop as a single callable.  :py:func:`adcc.nuclear_gradient_scanner` creates a
+stateful PySCF-based scanner which accepts Cartesian coordinates in Bohr and
+returns ``(energy, gradient)`` in Hartree and Hartree/Bohr:
+
+.. code-block:: python
+
+    scanner = adcc.nuclear_gradient_scanner(
+        mol_template=mol,
+        method="adc2",
+        state_index=0,
+        n_singlets=3,
+        scf_conv_tol=1e-11,
+    )
+
+    energy, gradient = scanner(mol.atom_coords())
+
+The scanner rebuilds the PySCF molecule at every geometry while keeping the
+original molecular and SCF settings fixed (basis, charge, spin/reference type,
+symmetry setting and SCF convergence options).  For geomeTRIC optimisations it
+is usually safest to construct the template molecule with ``symmetry=False`` or
+pass ``symmetry=False`` explicitly.  After the first step it seeds
+SCF from the previous converged density, which improves orbital continuity.
+For excited states the scanner stores the previous :class:`adcc.ExcitedStates`
+and selected :class:`adcc.Excitation`; by default it follows the state by
+comparing AO-basis transition and state-difference densities across geometries
+using PySCF AO cross-overlap integrals.  A fixed-index mode is available via
+``follow="index"`` for debugging or well-separated states.
+
+The same object also implements geomeTRIC's custom-engine ``calc_new`` protocol:
+
+.. code-block:: python
+
+    result = scanner.calc_new(mol.atom_coords().ravel())
+    # result == {"energy": energy, "gradient": gradient.ravel()}
+
+geomeTRIC remains an optional dependency; the plain scanner only requires the
+PySCF backend.  Minimum-energy crossing point workflows can be built from two
+scanner targets because geomeTRIC's penalty-constrained formulation only needs
+the two state energies and gradients, not derivative couplings.
+
 The two-electron term can be evaluated with two different strategies, selected
 through the ``eri_contraction`` keyword (see
 :ref:`gradients-eri-contraction` below). For the PySCF backend the

--- a/docs/gradients.rst
+++ b/docs/gradients.rst
@@ -50,33 +50,37 @@ Geometry optimisation scanners
 ------------------------------
 
 For geometry optimisers it is useful to expose the whole PySCF/adcc/gradient
-loop as a single callable.  :py:func:`adcc.nuclear_gradient_scanner` creates a
-stateful PySCF-based scanner which accepts Cartesian coordinates in Bohr and
-returns ``(energy, gradient)`` in Hartree and Hartree/Bohr:
+loop as a single callable.  :py:func:`adcc.nuclear_gradient_scanner` takes a
+configured PySCF SCF object as its template and accepts Cartesian coordinates in
+Bohr.  It returns ``(energy, gradient)`` in Hartree and Hartree/Bohr:
 
 .. code-block:: python
 
+    scfres = scf.RHF(mol)
+    scfres.conv_tol = 1e-11
+    scfres.conv_tol_grad = 1e-9
+
     scanner = adcc.nuclear_gradient_scanner(
-        mol_template=mol,
+        scfres,
         method="adc2",
         state_index=0,
         n_singlets=3,
-        scf_conv_tol=1e-11,
+        conv_tol=1e-7,  # forwarded unchanged to adcc.run_adc
     )
 
     energy, gradient = scanner(mol.atom_coords())
 
-The scanner rebuilds the PySCF molecule at every geometry while keeping the
-original molecular and SCF settings fixed (basis, charge, spin/reference type,
-symmetry setting and SCF convergence options).  For geomeTRIC optimisations it
-is usually safest to construct the template molecule with ``symmetry=False`` or
-pass ``symmetry=False`` explicitly.  After the first step it seeds
-SCF from the previous converged density, which improves orbital continuity.
-For excited states the scanner stores the previous :class:`adcc.ExcitedStates`
-and selected :class:`adcc.Excitation`; by default it follows the state by
-comparing AO-basis transition and state-difference densities across geometries
-using PySCF AO cross-overlap integrals.  A fixed-index mode is available via
-``follow="index"`` for debugging or well-separated states.
+The scanner uses PySCF's scanner machinery to rerun the SCF calculation at each
+new geometry with the original SCF object settings.  This keeps the SCF
+interface on the PySCF object, where users already configure basis, charge,
+spin/reference type, symmetry behaviour and convergence options.  For geomeTRIC
+optimisations it is usually safest to construct the PySCF molecule with
+``symmetry=False``.  PySCF's scanner also provides the SCF guess continuity
+between geometry steps.  For excited states the scanner stores the previous
+:class:`adcc.ExcitedStates` and selected :class:`adcc.Excitation`; by default it
+follows the state by comparing AO-basis transition and state-difference densities
+across geometries using PySCF AO cross-overlap integrals.  A fixed-index mode is
+available via ``follow="index"`` for debugging or well-separated states.
 
 The same object also implements geomeTRIC's custom-engine ``calc_new`` protocol:
 

--- a/examples/optimization/pyscf_adcc_geoopt.py
+++ b/examples/optimization/pyscf_adcc_geoopt.py
@@ -1,44 +1,43 @@
 #!/usr/bin/env python3
-"""Geometry optimisation with adcc nuclear gradients and geomeTRIC.
+"""Ground-state MP2 geometry optimisation with adcc gradients.
 
-This example uses the geomeTRIC custom-engine protocol.  geomeTRIC is optional;
-install it separately before running this script.
+The scanner is built from a configured PySCF SCF object.  PySCF owns all SCF
+settings and adcc runs MP2 plus the analytic gradient at each geometry.
 """
 
 import adcc
-from pyscf import gto
+from pyscf import gto, scf
+from pyscf.geomopt import as_pyscf_method, geometric_solver
 
 
 mol = gto.M(
-    atom="O 0 0 0; H 0 0 1.795239827225189; H 1.693194615993441 0 -0.599043184453037",
+    atom="""
+    O  0.000000000000  0.000000000000  0.000000000000
+    H  0.000000000000  0.000000000000  1.795239827225
+    H  1.693194615993  0.000000000000 -0.599043184453
+    """,
     basis="sto-3g",
     unit="Bohr",
+    symmetry=False,
     verbose=0,
 )
 
-scanner = adcc.nuclear_gradient_scanner(
-    mol_template=mol,
-    method="mp2",
-    scf_conv_tol=1e-11,
-    scf_conv_tol_grad=1e-9,
-)
+mf = scf.RHF(mol)
+mf.conv_tol = 1e-11
+mf.conv_tol_grad = 1e-9
 
-try:
-    from geometric.engine import Engine
-except ImportError as exc:
-    raise SystemExit("Install geomeTRIC to run this example: pip install geometric") from exc
+scanner = adcc.nuclear_gradient_scanner(mf, method="mp2")
 
 
-class AdccEngine(Engine):
-    def calc_new(self, coords, dirname):  # noqa: D102 - geomeTRIC protocol
-        return scanner.calc_new(coords)
+def energy_and_gradient(mol_at_step):
+    """PySCF geomopt callback: return energy and gradient for a Mole."""
+    return scanner(mol_at_step.atom_coords(unit="Bohr"))
 
 
-# For a complete script one also needs to create geomeTRIC's Molecule,
-# InternalCoordinates and OptParams objects (or use geomeTRIC's Python helpers)
-# and pass this engine to run_optimizer.  The important adcc-specific part is
-# the scanner above: it runs PySCF at each geometry, hands the converged SCF
-# result to adcc, evaluates the MP2 gradient, and returns geomeTRIC's
-# {"energy", "gradient"} dictionary.
-print("Initial energy / gradient:")
-print(scanner.calc_new(mol.atom_coords().ravel()))
+if __name__ == "__main__":
+    method = as_pyscf_method(mol, energy_and_gradient)
+    mol_eq = geometric_solver.optimize(method, maxsteps=20)
+
+    print("\nOptimised geometry (Bohr):")
+    for symbol, xyz in zip(scanner.atom_symbols, mol_eq.atom_coords(unit="Bohr")):
+        print(f"{symbol:2s} {xyz[0]:16.10f} {xyz[1]:16.10f} {xyz[2]:16.10f}")

--- a/examples/optimization/pyscf_adcc_geoopt.py
+++ b/examples/optimization/pyscf_adcc_geoopt.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Geometry optimisation with adcc nuclear gradients and geomeTRIC.
+
+This example uses the geomeTRIC custom-engine protocol.  geomeTRIC is optional;
+install it separately before running this script.
+"""
+
+import adcc
+from pyscf import gto
+
+
+mol = gto.M(
+    atom="O 0 0 0; H 0 0 1.795239827225189; H 1.693194615993441 0 -0.599043184453037",
+    basis="sto-3g",
+    unit="Bohr",
+    verbose=0,
+)
+
+scanner = adcc.nuclear_gradient_scanner(
+    mol_template=mol,
+    method="mp2",
+    scf_conv_tol=1e-11,
+    scf_conv_tol_grad=1e-9,
+)
+
+try:
+    from geometric.engine import Engine
+except ImportError as exc:
+    raise SystemExit("Install geomeTRIC to run this example: pip install geometric") from exc
+
+
+class AdccEngine(Engine):
+    def calc_new(self, coords, dirname):  # noqa: D102 - geomeTRIC protocol
+        return scanner.calc_new(coords)
+
+
+# For a complete script one also needs to create geomeTRIC's Molecule,
+# InternalCoordinates and OptParams objects (or use geomeTRIC's Python helpers)
+# and pass this engine to run_optimizer.  The important adcc-specific part is
+# the scanner above: it runs PySCF at each geometry, hands the converged SCF
+# result to adcc, evaluates the MP2 gradient, and returns geomeTRIC's
+# {"energy", "gradient"} dictionary.
+print("Initial energy / gradient:")
+print(scanner.calc_new(mol.atom_coords().ravel()))

--- a/examples/optimization/pyscf_adcc_geoopt_excited.py
+++ b/examples/optimization/pyscf_adcc_geoopt_excited.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Excited-state geometry optimisation with adcc gradients.
+
+This example uses :func:`adcc.nuclear_gradient_scanner` to expose an ADC excited
+state as a PySCF/geomeTRIC-compatible energy-gradient callable.  The scanner
+uses the configured PySCF SCF object as its template, then runs adcc and follows
+the selected excited state with AO-basis transition/state-difference density
+overlaps.
+
+geomeTRIC is optional; install it separately, e.g. ``pip install geometric`` or
+``pip install adcc[geomopt]`` once the optional extra is available.
+"""
+
+import adcc
+from pyscf import gto, scf
+from pyscf.geomopt import as_pyscf_method, geometric_solver
+
+
+# Use Bohr coordinates and keep molecular symmetry disabled so the optimizer's
+# Cartesian frame and the gradient frame stay identical during the scan.
+mol = gto.M(
+    atom="""
+    O  0.000000000000  0.000000000000  0.000000000000
+    H  0.000000000000  0.000000000000  1.795239827225
+    H  1.693194615993  0.000000000000 -0.599043184453
+    """,
+    basis="sto-3g",
+    unit="Bohr",
+    symmetry=False,
+    verbose=0,
+)
+
+# Configure SCF entirely on the PySCF object.  The scanner will use this object
+# as the template and PySCF will preserve SCF guess continuity between geometry
+# steps.
+mf = scf.RHF(mol)
+mf.conv_tol = 1e-11
+mf.conv_tol_grad = 1e-9
+
+# Optimise the lowest singlet ADC(2) state.  Requesting a few singlet roots lets
+# the scanner compare candidates and follow the same physical state if root
+# ordering changes along the optimisation.  adcc keyword arguments such as
+# conv_tol and n_singlets are forwarded unchanged to adcc.run_adc.
+scanner = adcc.nuclear_gradient_scanner(
+    mf,
+    method="adc2",
+    state_index=0,
+    n_singlets=3,
+    follow="overlap",
+    conv_tol=1e-7,
+)
+
+
+def energy_and_gradient(mol_at_step):
+    """PySCF geomopt callback: return energy and gradient for a Mole."""
+    energy, gradient = scanner(mol_at_step.atom_coords(unit="Bohr"))
+    print(
+        f"E = {energy:.12f} Eh, |g| = "
+        f"{float((gradient ** 2).sum() ** 0.5):.6e} Eh/Bohr"
+    )
+    return energy, gradient
+
+
+if __name__ == "__main__":
+    method = as_pyscf_method(mol, energy_and_gradient)
+    mol_eq = geometric_solver.optimize(
+        method,
+        maxsteps=20,
+        convergence_grms=1e-3,
+        convergence_gmax=1.5e-3,
+    )
+
+    print("\nOptimised geometry (Bohr):")
+    for symbol, xyz in zip(scanner.atom_symbols, mol_eq.atom_coords(unit="Bohr")):
+        print(f"{symbol:2s} {xyz[0]:16.10f} {xyz[1]:16.10f} {xyz[2]:16.10f}")

--- a/examples/optimization/pyscf_adcc_geoopt_excited.py
+++ b/examples/optimization/pyscf_adcc_geoopt_excited.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """Excited-state geometry optimisation with adcc gradients.
 
-This example first relaxes water on the MP2 ground-state surface and then uses
-that geometry as the starting point for an ADC(2) excited-state optimisation.
-The :func:`adcc.nuclear_gradient_scanner` is built from a configured PySCF SCF
+This example reproduces the s-trans-butadiene setup used as a geometry
+optimisation showcase by Rehn & Dreuw (*J. Chem. Phys.* 150, 174110, 2019).
+It first relaxes the molecule on the MP2 ground-state surface and then uses that
+geometry as the starting point for an ADC(2) excited-state optimisation.  The
+:func:`adcc.nuclear_gradient_scanner` is built from a configured PySCF SCF
 object, so PySCF owns all SCF settings while adcc keyword arguments are passed
 unchanged to :func:`adcc.run_adc`.
 
@@ -52,13 +54,21 @@ def make_energy_gradient(scanner):
 
 # Use Bohr coordinates and keep molecular symmetry disabled so the optimizer's
 # Cartesian frame and the gradient frame stay identical during the scan.
+# s-trans-butadiene (C4H6), planar all-trans conformation.
 mol = gto.M(
     atom="""
-    O  0.000000000000  0.000000000000  0.000000000000
-    H  0.000000000000  0.000000000000  1.795239827225
-    H  1.693194615993  0.000000000000 -0.599043184453
+C     -3.4705405625     0.4297233578    -0.0000000000
+C     -1.1911517402    -0.6904425316     0.0000000000
+C      1.1911517402     0.6904425315     0.0000000000
+C      3.4705405625    -0.4297233578    -0.0000000000
+H     -3.6579517613     2.4744185046    -0.0000000000
+H     -5.2070544325    -0.6589625683     0.0000000000
+H     -1.0698622893    -2.7464869632     0.0000000000
+H      1.0698622893     2.7464869632     0.0000000000
+H      3.6579517613    -2.4744185046    -0.0000000000
+H      5.2070544325     0.6589625682     0.0000000000
     """,
-    basis="cc-pvdz",
+    basis="6-31G*",
     unit="Bohr",
     symmetry=False,
     verbose=0,

--- a/examples/optimization/pyscf_adcc_geoopt_excited.py
+++ b/examples/optimization/pyscf_adcc_geoopt_excited.py
@@ -29,7 +29,8 @@ def make_scf(mol):
 def print_geometry(title, mol):
     print(f"\n{title} (Bohr):")
     for i, xyz in enumerate(mol.atom_coords(unit="Bohr")):
-        print(f"{mol.atom_symbol(i):2s} {xyz[0]:16.10f} {xyz[1]:16.10f} {xyz[2]:16.10f}")
+        print(f"{mol.atom_symbol(i):2s} "
+              f"{xyz[0]:16.10f} {xyz[1]:16.10f} {xyz[2]:16.10f}")
 
 
 def make_energy_gradient(scanner):

--- a/examples/optimization/pyscf_adcc_geoopt_excited.py
+++ b/examples/optimization/pyscf_adcc_geoopt_excited.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """Excited-state geometry optimisation with adcc gradients.
 
-This example uses :func:`adcc.nuclear_gradient_scanner` to expose an ADC excited
-state as a PySCF/geomeTRIC-compatible energy-gradient callable.  The scanner
-uses the configured PySCF SCF object as its template, then runs adcc and follows
-the selected excited state with AO-basis transition/state-difference density
-overlaps.
+This example first relaxes water on the MP2 ground-state surface and then uses
+that geometry as the starting point for an ADC(2) excited-state optimisation.
+The :func:`adcc.nuclear_gradient_scanner` is built from a configured PySCF SCF
+object, so PySCF owns all SCF settings while adcc keyword arguments are passed
+unchanged to :func:`adcc.run_adc`.
 
 geomeTRIC is optional; install it separately, e.g. ``pip install geometric`` or
 ``pip install adcc[geomopt]`` once the optional extra is available.
@@ -16,6 +16,40 @@ from pyscf import gto, scf
 from pyscf.geomopt import as_pyscf_method, geometric_solver
 
 
+def make_scf(mol):
+    """Build the PySCF reference used as scanner template."""
+    mf = scf.RHF(mol)
+    mf.conv_tol = 1e-10
+    mf.conv_tol_grad = 1e-6
+    return mf
+
+
+def print_geometry(title, mol):
+    print(f"\n{title} (Bohr):")
+    for i, xyz in enumerate(mol.atom_coords(unit="Bohr")):
+        print(f"{mol.atom_symbol(i):2s} {xyz[0]:16.10f} {xyz[1]:16.10f} {xyz[2]:16.10f}")
+
+
+def make_energy_gradient(scanner):
+    """PySCF geomopt callback: return energy and gradient for a Mole."""
+    def energy_and_gradient(mol_at_step):
+        energy, gradient = scanner(mol_at_step.atom_coords(unit="Bohr"))
+        excitation = scanner.last_excitation
+        state_info = ""
+        if excitation is not None:
+            state_info = (
+                f", state = {excitation.index}, "
+                f"omega = {excitation.excitation_energy:.8f} Eh"
+            )
+        print(
+            f"E = {energy:.12f} Eh, |g| = "
+            f"{float((gradient ** 2).sum() ** 0.5):.6e} Eh/Bohr"
+            f"{state_info}"
+        )
+        return energy, gradient
+    return energy_and_gradient
+
+
 # Use Bohr coordinates and keep molecular symmetry disabled so the optimizer's
 # Cartesian frame and the gradient frame stay identical during the scan.
 mol = gto.M(
@@ -24,52 +58,50 @@ mol = gto.M(
     H  0.000000000000  0.000000000000  1.795239827225
     H  1.693194615993  0.000000000000 -0.599043184453
     """,
-    basis="sto-3g",
+    basis="cc-pvdz",
     unit="Bohr",
     symmetry=False,
     verbose=0,
 )
 
-# Configure SCF entirely on the PySCF object.  The scanner will use this object
-# as the template and PySCF will preserve SCF guess continuity between geometry
-# steps.
-mf = scf.RHF(mol)
-mf.conv_tol = 1e-11
-mf.conv_tol_grad = 1e-9
-
-# Optimise the lowest singlet ADC(2) state.  Requesting a few singlet roots lets
-# the scanner compare candidates and follow the same physical state if root
-# ordering changes along the optimisation.  adcc keyword arguments such as
-# conv_tol and n_singlets are forwarded unchanged to adcc.run_adc.
-scanner = adcc.nuclear_gradient_scanner(
-    mf,
-    method="adc2",
-    state_index=0,
-    n_singlets=3,
-    follow="overlap",
-    conv_tol=1e-7,
-)
-
-
-def energy_and_gradient(mol_at_step):
-    """PySCF geomopt callback: return energy and gradient for a Mole."""
-    energy, gradient = scanner(mol_at_step.atom_coords(unit="Bohr"))
-    print(
-        f"E = {energy:.12f} Eh, |g| = "
-        f"{float((gradient ** 2).sum() ** 0.5):.6e} Eh/Bohr"
-    )
-    return energy, gradient
-
 
 if __name__ == "__main__":
-    method = as_pyscf_method(mol, energy_and_gradient)
-    mol_eq = geometric_solver.optimize(
-        method,
+    print_geometry("Initial geometry", mol)
+
+    # Stage 1: relax the ground-state structure at MP2 level.  This provides a
+    # much better starting point for the subsequent state-specific optimisation
+    # than the arbitrary input geometry.
+    mp2_scanner = adcc.nuclear_gradient_scanner(
+        make_scf(mol),
+        method="mp2",
+        gradient_kwargs={"conv_tol": 1e-7},
+    )
+    mp2_method = as_pyscf_method(mol, make_energy_gradient(mp2_scanner))
+    mol_mp2 = geometric_solver.optimize(
+        mp2_method,
         maxsteps=20,
         convergence_grms=1e-3,
         convergence_gmax=1.5e-3,
     )
+    print_geometry("MP2-optimised geometry", mol_mp2)
 
-    print("\nOptimised geometry (Bohr):")
-    for symbol, xyz in zip(scanner.atom_symbols, mol_eq.atom_coords(unit="Bohr")):
-        print(f"{symbol:2s} {xyz[0]:16.10f} {xyz[1]:16.10f} {xyz[2]:16.10f}")
+    # Stage 2: optimise the lowest singlet ADC(2) state.  Requesting a few
+    # singlet roots lets the scanner compare candidates and follow the same
+    # physical state if root ordering changes along the optimisation.
+    adc_scanner = adcc.nuclear_gradient_scanner(
+        make_scf(mol_mp2),
+        method="adc2",
+        state_index=0,
+        n_singlets=3,
+        follow="overlap",
+        conv_tol=1e-6,
+        gradient_kwargs={"conv_tol": 1e-7},
+    )
+    adc_method = as_pyscf_method(mol_mp2, make_energy_gradient(adc_scanner))
+    mol_adc = geometric_solver.optimize(
+        adc_method,
+        maxsteps=20,
+        convergence_grms=1e-3,
+        convergence_gmax=1.5e-3,
+    )
+    print_geometry("ADC(2)-optimised demonstration geometry", mol_adc)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ build_docs = [
 	"sphinx-automodapi", "sphinx-rtd-theme"
 ]
 analysis = ["matplotlib >= 3.0", "pandas >= 0.25.0"]
+geomopt = ["geometric"]
 build_stub = ["ruff", "pybind11-stubgen"]
 
 [project.urls]


### PR DESCRIPTION
Closes #221

Adds a planned implementation path for a PySCF/adcc nuclear-gradient scanner for geometry optimization, including geomeTRIC integration, state following, and MECP support.

Implementation plan posted as a comment below.
