### PR TITLE
Refactor Arithmetic Operations on AmplitudeVector

### DIFF
--- a/adcc/AmplitudeVector.py
+++ b/adcc/AmplitudeVector.py
@@ -168,6 +168,9 @@ class AmplitudeVector(dict[str, libadcc.Tensor]):
     ) -> "AmplitudeVector":
         if isinstance(other, AmplitudeVector):
             return other.__mul__(self)
+        # This path is not reachable currently, because the libadcc backend
+        # raises a TypeError instead of returning NotImplemented.
+        # Thus, the reflective operations are not called in this case.
         elif isinstance(other, libadcc.Tensor):
             ret = {block: other.__mul__(tensor) for block, tensor in self.items()}
         else:  # float
@@ -214,6 +217,9 @@ class AmplitudeVector(dict[str, libadcc.Tensor]):
     ) -> "AmplitudeVector":
         if isinstance(other, AmplitudeVector):
             return other.__add__(self)
+        # This path is not reachable currently, because the libadcc backend
+        # raises a TypeError instead of returning NotImplemented.
+        # Thus, the reflective operations are not called in this case.
         elif isinstance(other, libadcc.Tensor):
             ret = {block: other.__add__(tensor) for block, tensor in self.items()}
         else:  # float
@@ -258,6 +264,9 @@ class AmplitudeVector(dict[str, libadcc.Tensor]):
     ) -> "AmplitudeVector":
         if isinstance(other, AmplitudeVector):
             return other.__sub__(self)
+        # This path is not reachable currently, because the libadcc backend
+        # raises a TypeError instead of returning NotImplemented.
+        # Thus, the reflective operations are not called in this case.
         elif isinstance(other, libadcc.Tensor):
             ret = {block: other.__sub__(tensor) for block, tensor in self.items()}
         else:  # float

--- a/adcc/AmplitudeVector.py
+++ b/adcc/AmplitudeVector.py
@@ -171,10 +171,10 @@ class AmplitudeVector(dict[str, libadcc.Tensor]):
         # tensor operations in the backend are curently not really in-place
         # erase all blocks that are missing in other and update the common blocks
         if isinstance(other, AmplitudeVector):
-            for block, tensor in self.items():
-                if block in other:
-                    self[block] = tensor.__mul__(other[block])
-                else:
+            for block in self.keys() | other.keys():
+                if block in self and block in other:
+                    self[block] = self[block].__mul__(other[block])
+                elif block in self:
                     del self[block]
         elif isinstance(other, libadcc.Tensor):
             for block, tensor in self.items():
@@ -309,8 +309,6 @@ class AmplitudeVector(dict[str, libadcc.Tensor]):
                         f"zero blocks. Self contains {self.blocks}. Other contains "
                         f"{other.blocks}."
                     )
-                else:  # 0 / x
-                    del self[block]
         elif isinstance(other, libadcc.Tensor):
             for block, tensor in self.items():
                 self[block] = tensor.__truediv__(other)

--- a/adcc/AmplitudeVector.py
+++ b/adcc/AmplitudeVector.py
@@ -114,10 +114,17 @@ class AmplitudeVector(dict[str, libadcc.Tensor]):
         Only blocks common to self and other are considered for the dot product.
         """
         if isinstance(other, Sequence):
-            return np.fromiter(
-                (self.dot(ten) for ten in other), dtype=np.float64, count=len(other)
-            )
-        return sum(self[b].dot(other[b]) for b in self.keys() & other.keys())
+            ret = np.zeros(len(other))
+            for block, tensor in self.items():
+                idx = [i for i, vec in enumerate(other) if block in vec]
+                if idx:
+                    # use "fast path" that computes the overlap with
+                    # multiple tensors at once in the backend
+                    ret[idx] += tensor.dot([other[i][block] for i in idx])
+            return ret
+        return sum(
+            self[b].dot(other[b]) for b in sorted(self.keys() & other.keys())
+        )
 
     @overload
     def __matmul__(self, other: "AmplitudeVector") -> float:
@@ -168,7 +175,7 @@ class AmplitudeVector(dict[str, libadcc.Tensor]):
     def __imul__(
         self, other: "AmplitudeVector | libadcc.Tensor | float"
     ) -> "AmplitudeVector":
-        # tensor operations in the backend are curently not really in-place
+        # tensor operations in the backend are currently not really in-place
         # erase all blocks that are missing in other and update the common blocks
         if isinstance(other, AmplitudeVector):
             for block in self.keys() | other.keys():
@@ -300,15 +307,14 @@ class AmplitudeVector(dict[str, libadcc.Tensor]):
         # missing block in other: x / 0 -> division by zero
         # missing block in self: 0 / x = 0 -> fine but not in result
         if isinstance(other, AmplitudeVector):
-            for block in self.keys() | other.keys():
-                if block in self and block in other:
-                    self[block] = self[block].__truediv__(other[block])
-                elif block in self:  # x / 0
-                    raise ZeroDivisionError(
-                        "Divisian by zero, since missing blocks are treated as "
-                        f"zero blocks. Self contains {self.blocks}. Other contains "
-                        f"{other.blocks}."
-                    )
+            if any(block not in other for block in self.keys()):
+                raise ZeroDivisionError(
+                    "Divisian by zero, since missing blocks are treated as "
+                    f"zero blocks. Self contains {self.blocks}. Other contains "
+                    f"{other.blocks}."
+                )
+            for block, tensor in self.items():
+                self[block] = tensor.__truediv__(other[block])
         elif isinstance(other, libadcc.Tensor):
             for block, tensor in self.items():
                 self[block] = tensor.__truediv__(other)

--- a/adcc/AmplitudeVector.py
+++ b/adcc/AmplitudeVector.py
@@ -2,7 +2,7 @@
 ## vi: tabstop=4 shiftwidth=4 softtabstop=4 expandtab
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2018 by the adcc authors
+## Copyright (C) 2026 by the adcc authors
 ##
 ## This file is part of adcc.
 ##
@@ -20,146 +20,304 @@
 ## along with adcc. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## ---------------------------------------------------------------------
+from typing import Sequence, overload
+import numpy as np
+
+import libadcc
 
 
-class AmplitudeVector(dict):
-    def __init__(self, **kwargs):
+class AmplitudeVector(dict[str, libadcc.Tensor]):
+    def __init__(self, **kwargs: libadcc.Tensor):
         """
         Construct an AmplitudeVector. Typical use cases are
         ``AmplitudeVector(ph=tensor_singles, pphh=tensor_doubles)``.
         """
         super().__init__(**kwargs)
 
-    def __getattr__(self, key):
+    def __getattr__(self, key: str) -> libadcc.Tensor:
         if self.__contains__(key):
             return self.__getitem__(key)
         raise AttributeError
 
-    def __setattr__(self, key, item):
+    def __setattr__(self, key: str, item: libadcc.Tensor) -> None:
         if self.__contains__(key):
             return self.__setitem__(key, item)
         raise AttributeError
 
     @property
-    def blocks(self):
+    def blocks(self) -> list[str]:
         """
-        Return the blocks which are used inside the vector.
+        Return the sorted blocks which are used inside the vector, e.g.,
+        ['ph', 'pphh'].
         """
         return sorted(self.keys())
 
-    def copy(self):
+    def copy(self) -> "AmplitudeVector":
         """Return a copy of the AmplitudeVector"""
         return AmplitudeVector(**{k: t.copy() for k, t in self.items()})
 
-    def evaluate(self):
+    def evaluate(self) -> "AmplitudeVector":
+        """
+        Ensures all blocks of the AmplitudeVector are evaluated and
+        resilient in memory.
+        """
         for t in self.values():
             t.evaluate()
         return self
 
     @property
-    def needs_evaluation(self):
+    def needs_evaluation(self) -> "bool":
         return any(t.needs_evaluation for _, t in self.items())
 
-    def ones_like(self):
+    def ones_like(self) -> "AmplitudeVector":
         """Return an empty AmplitudeVector of the same shape and symmetry"""
         return AmplitudeVector(**{k: t.ones_like() for k, t in self.items()})
 
-    def empty_like(self):
+    def empty_like(self) -> "AmplitudeVector":
         """Return an empty AmplitudeVector of the same shape and symmetry"""
         return AmplitudeVector(**{k: t.empty_like() for k, t in self.items()})
 
-    def nosym_like(self):
+    def nosym_like(self) -> "AmplitudeVector":
         """Return an empty AmplitudeVector of the same shape and symmetry"""
         return AmplitudeVector(**{k: t.nosym_like() for k, t in self.items()})
 
-    def zeros_like(self):
+    def zeros_like(self) -> "AmplitudeVector":
         """Return an AmplitudeVector of the same shape and symmetry with
-           all elements set to zero"""
+        all elements set to zero"""
         return AmplitudeVector(**{k: t.zeros_like() for k, t in self.items()})
 
-    def set_random(self):
+    def set_random(self) -> "AmplitudeVector":
+        """
+        Fills all blocks of the AmplitudeVector with random elements.
+        """
         for t in self.values():
             t.set_random()
         return self
 
-    def dot(self, other):
-        """Return the dot product with another AmplitudeVector
+    @overload
+    def dot(self, other: "AmplitudeVector") -> float:
+        ...
+
+    @overload
+    def dot(
+        self, other: Sequence["AmplitudeVector"]
+    ) -> np.ndarray[tuple[int], np.dtype[np.float64]]:
+        ...
+
+    def dot(
+        self, other: Sequence["AmplitudeVector"] | "AmplitudeVector"
+    ) -> np.ndarray[tuple[int], np.dtype[np.float64]] | float:
+        """
+        Return the dot product with another AmplitudeVector
         or the dot products with a list of AmplitudeVectors.
         In the latter case a np.ndarray is returned.
+        Only blocks common to self and other are considered for the dot product.
         """
-        if isinstance(other, list):
-            # Make a list where the first index is all singles parts,
-            # the second is all doubles parts and so on
-            return sum(self[b].dot([av[b] for av in other]) for b in self.keys())
-        else:
-            return sum(self[b].dot(other[b]) for b in self.keys())
+        if isinstance(other, Sequence):
+            return np.fromiter(
+                (self.dot(ten) for ten in other), dtype=np.float64, count=len(other)
+            )
+        return sum(self[b].dot(other[b]) for b in self.keys() & other.keys())
 
-    def __matmul__(self, other):
+    @overload
+    def __matmul__(self, other: "AmplitudeVector") -> float:
+        ...
+
+    @overload
+    def __matmul__(
+        self, other: Sequence["AmplitudeVector"]
+    ) -> np.ndarray[tuple[int], np.dtype[np.float64]]:
+        ...
+
+    def __matmul__(
+        self, other: Sequence["AmplitudeVector"] | "AmplitudeVector"
+    ) -> np.ndarray[tuple[int], np.dtype[np.float64]] | float:
         if isinstance(other, AmplitudeVector):
             return self.dot(other)
-        if isinstance(other, list):
-            if all(isinstance(elem, AmplitudeVector) for elem in other):
-                return self.dot(other)
+        elif isinstance(other, Sequence) and all(
+            isinstance(t, AmplitudeVector) for t in other
+        ):
+            return self.dot(other)
         return NotImplemented
 
-    def __forward_to_blocks(self, fname, other):
+    def __mul__(
+        self, other: "AmplitudeVector | libadcc.Tensor | float"
+    ) -> "AmplitudeVector":
+        # missing blocks can be treated as multiplying by zero
+        # and omited in the result Vector
         if isinstance(other, AmplitudeVector):
-            if sorted(other.blocks) != sorted(self.blocks):
-                raise ValueError("Blocks of both AmplitudeVector objects "
-                                 f"need to agree to perform {fname}")
-            ret = {k: getattr(tensor, fname)(other[k])
-                   for k, tensor in self.items()}
+            ret = {
+                block: self[block].__mul__(other[block])
+                for block in self.keys() & other.keys()
+            }
         else:
-            ret = {k: getattr(tensor, fname)(other) for k, tensor in self.items()}
-        if any(r == NotImplemented for r in ret.values()):
-            return NotImplemented
+            ret = {block: self[block].__mul__(other) for block in self.keys()}
+        return AmplitudeVector(**ret)
+
+    def __rmul__(
+        self, other: "AmplitudeVector | libadcc.Tensor | float"
+    ) -> "AmplitudeVector":
+        if isinstance(other, AmplitudeVector):
+            return other.__mul__(self)
+        elif isinstance(other, libadcc.Tensor):
+            ret = {block: other.__mul__(tensor) for block, tensor in self.items()}
+        else:  # float
+            ret = {block: tensor.__rmul__(other) for block, tensor in self.items()}
+        return AmplitudeVector(**ret)
+
+    def __imul__(
+        self, other: "AmplitudeVector | libadcc.Tensor | float"
+    ) -> "AmplitudeVector":
+        # tensor operations in the backend are curently not really in-place
+        # erase all blocks that are missing in other and update the common blocks
+        if isinstance(other, AmplitudeVector):
+            for block, tensor in self.items():
+                if block in other:
+                    self[block] = tensor.__mul__(other[block])
+                else:
+                    del self[block]
+        elif isinstance(other, libadcc.Tensor):
+            for block, tensor in self.items():
+                self[block] = tensor.__mul__(other)
+        else:  # float
+            for block, tensor in self.items():
+                self[block] = tensor.__imul__(other)
+        return self
+
+    def __add__(
+        self, other: "AmplitudeVector | libadcc.Tensor | float"
+    ) -> "AmplitudeVector":
+        if isinstance(other, AmplitudeVector):
+            ret = {}
+            for block in self.keys() | other.keys():
+                if block in self and block in other:
+                    ret[block] = self[block].__add__(other[block])
+                elif block in self:  # x + 0
+                    ret[block] = self[block].copy()
+                else:  # 0 + x
+                    ret[block] = other[block].copy()
         else:
-            return AmplitudeVector(**ret)
+            ret = {block: tensor.__add__(other) for block, tensor in self.items()}
+        return AmplitudeVector(**ret)
 
-    def __mul__(self, other):
-        return self.__forward_to_blocks("__mul__", other)
+    def __radd__(
+        self, other: "AmplitudeVector | libadcc.Tensor | float"
+    ) -> "AmplitudeVector":
+        if isinstance(other, AmplitudeVector):
+            return other.__add__(self)
+        elif isinstance(other, libadcc.Tensor):
+            ret = {block: other.__add__(tensor) for block, tensor in self.items()}
+        else:  # float
+            ret = {block: tensor.__radd__(other) for block, tensor in self.items()}
+        return AmplitudeVector(**ret)
 
-    def __rmul__(self, other):
-        return self.__forward_to_blocks("__rmul__", other)
+    def __iadd__(
+        self, other: "AmplitudeVector | libadcc.Tensor"
+    ) -> "AmplitudeVector":
+        # not really in-place in the backend!
+        # missing block in self: 0 + x = x -> copy the other block
+        # missing block in other: x + 0 = x -> nothing to do
+        if isinstance(other, AmplitudeVector):
+            for block, tensor in other.items():
+                if block in self:
+                    self[block] = self[block].__iadd__(tensor)
+                else:
+                    self[block] = tensor.copy()
+        else:
+            for block, tensor in self.items():
+                self[block] = tensor.__iadd__(other)
+        return self
 
-    def __sub__(self, other):
-        return self.__forward_to_blocks("__sub__", other)
+    def __sub__(
+        self, other: "AmplitudeVector | libadcc.Tensor | float"
+    ) -> "AmplitudeVector":
+        if isinstance(other, AmplitudeVector):
+            ret = {}
+            for block in self.keys() | other.keys():
+                if block in self and block in other:
+                    ret[block] = self[block].__sub__(other[block])
+                elif block in self:  # x - 0
+                    ret[block] = self[block].copy()
+                else:  # 0 - x
+                    ret[block] = other[block].__neg__()
+        else:
+            ret = {block: self[block].__sub__(other) for block in self.keys()}
+        return AmplitudeVector(**ret)
 
-    def __rsub__(self, other):
-        return self.__forward_to_blocks("__rsub__", other)
+    def __rsub__(
+        self, other: "AmplitudeVector | libadcc.Tensor | float"
+    ) -> "AmplitudeVector":
+        if isinstance(other, AmplitudeVector):
+            return other.__sub__(self)
+        elif isinstance(other, libadcc.Tensor):
+            ret = {block: other.__sub__(tensor) for block, tensor in self.items()}
+        else:  # float
+            ret = {block: tensor.__rsub__(other) for block, tensor in self.items()}
+        return AmplitudeVector(**ret)
 
-    def __truediv__(self, other):
-        return self.__forward_to_blocks("__truediv__", other)
+    def __isub__(
+        self, other: "AmplitudeVector | libadcc.Tensor"
+    ) -> "AmplitudeVector":
+        # not really in-place in the backend!
+        # missing block in self: 0 - x = -x
+        # missing block in other: x - 0 = x -> nothing to do
+        if isinstance(other, AmplitudeVector):
+            for block, tensor in other.items():
+                if block in self:
+                    self[block] = self[block].__isub__(tensor)
+                else:
+                    self[block] = tensor.__neg__()
+        else:
+            for block, tensor in self.items():
+                self[block] = tensor.__isub__(other)
+        return self
 
-    def __imul__(self, other):
-        return self.__forward_to_blocks("__imul__", other)
+    def __truediv__(
+        self, other: "AmplitudeVector | libadcc.Tensor | float"
+    ) -> "AmplitudeVector":
+        # here all blocks of other have to be in self present, too!
+        # block missing in other: x / 0 -> division by zero
+        # block missing in self: 0 / x = 0 -> fine but not in result
+        if isinstance(other, AmplitudeVector):
+            if any(block not in other for block in self.keys()):
+                raise ZeroDivisionError(
+                    "Divisian by zero, since missing blocks are treated as "
+                    f"zero blocks. Self contains {self.blocks}. Other contains "
+                    f"{other.blocks}."
+                )
+            ret = {
+                block: self[block].__truediv__(other[block])
+                for block in self.keys() & other.keys()
+            }
+        else:
+            ret = {block: self[block].__truediv__(other) for block in self.keys()}
+        return AmplitudeVector(**ret)
 
-    def __iadd__(self, other):
-        return self.__forward_to_blocks("__iadd__", other)
-
-    def __isub__(self, other):
-        return self.__forward_to_blocks("__isub__", other)
-
-    def __itruediv__(self, other):
-        return self.__forward_to_blocks("__itruediv__", other)
+    def __itruediv__(
+        self, other: "AmplitudeVector | libadcc.Tensor | float"
+    ) -> "AmplitudeVector":
+        # not really in-place in the backend!
+        # missing block in other: x / 0 -> division by zero
+        # missing block in self: 0 / x = 0 -> fine but not in result
+        if isinstance(other, AmplitudeVector):
+            for block in self.keys() | other.keys():
+                if block in self and block in other:
+                    self[block] = self[block].__truediv__(other[block])
+                elif block in self:  # x / 0
+                    raise ZeroDivisionError(
+                        "Divisian by zero, since missing blocks are treated as "
+                        f"zero blocks. Self contains {self.blocks}. Other contains "
+                        f"{other.blocks}."
+                    )
+                else:  # 0 / x
+                    del self[block]
+        elif isinstance(other, libadcc.Tensor):
+            for block, tensor in self.items():
+                self[block] = tensor.__truediv__(other)
+        else:  # float
+            for block, tensor in self.items():
+                self[block] = tensor.__itruediv__(other)
+        return self
 
     def __repr__(self):
         return "AmplitudeVector(" + "=..., ".join(self.blocks) + "=...)"
-
-    # __add__ is special because we want to be able to add AmplitudeVectors
-    # with missing blocks
-    def __add__(self, other):
-        if isinstance(other, AmplitudeVector):
-            allblocks = sorted(set(self.blocks).union(other.blocks))
-            ret = {k: self.get(k, 0) + other.get(k, 0) for k in allblocks}
-            ret = {k: v for k, v in ret.items() if v != 0}
-        else:
-            ret = {k: tensor + other for k, tensor in self.items()}
-        return AmplitudeVector(**ret)
-
-    def __radd__(self, other):
-        if isinstance(other, AmplitudeVector):
-            return other.__add__(self)
-        else:
-            ret = {k: other + tensor for k, tensor in self.items()}
-            return AmplitudeVector(**ret)

--- a/adcc/AmplitudeVector.py
+++ b/adcc/AmplitudeVector.py
@@ -20,7 +20,8 @@
 ## along with adcc. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## ---------------------------------------------------------------------
-from typing import Sequence, overload
+from collections.abc import Sequence
+from typing import overload
 import numpy as np
 
 import libadcc
@@ -105,7 +106,7 @@ class AmplitudeVector(dict[str, libadcc.Tensor]):
         ...
 
     def dot(
-        self, other: Sequence["AmplitudeVector"] | "AmplitudeVector"
+        self, other: "Sequence[AmplitudeVector] | AmplitudeVector"
     ) -> np.ndarray[tuple[int], np.dtype[np.float64]] | float:
         """
         Return the dot product with another AmplitudeVector
@@ -123,7 +124,8 @@ class AmplitudeVector(dict[str, libadcc.Tensor]):
                     ret[idx] += tensor.dot([other[i][block] for i in idx])
             return ret
         return sum(
-            self[b].dot(other[b]) for b in sorted(self.keys() & other.keys())
+            (self[b].dot(other[b]) for b in sorted(self.keys() & other.keys())),
+            0.0  # so we always return a float even when the intersection is empty
         )
 
     @overload
@@ -137,7 +139,7 @@ class AmplitudeVector(dict[str, libadcc.Tensor]):
         ...
 
     def __matmul__(
-        self, other: Sequence["AmplitudeVector"] | "AmplitudeVector"
+        self, other: "Sequence[AmplitudeVector] | AmplitudeVector"
     ) -> np.ndarray[tuple[int], np.dtype[np.float64]] | float:
         if isinstance(other, AmplitudeVector):
             return self.dot(other)
@@ -293,8 +295,8 @@ class AmplitudeVector(dict[str, libadcc.Tensor]):
                     f"{other.blocks}."
                 )
             ret = {
-                block: self[block].__truediv__(other[block])
-                for block in self.keys() & other.keys()
+                block: tensor.__truediv__(other[block])
+                for block, tensor in self.items()
             }
         else:
             ret = {block: self[block].__truediv__(other) for block in self.keys()}
@@ -324,4 +326,7 @@ class AmplitudeVector(dict[str, libadcc.Tensor]):
         return self
 
     def __repr__(self):
-        return "AmplitudeVector(" + "=..., ".join(self.blocks) + "=...)"
+        if self:
+            return f"AmplitudeVector({'=..., '.join(self.blocks)}=...)"
+        else:  # empty vector
+            return "AmplitudeVector()"

--- a/adcc/AmplitudeVector.py
+++ b/adcc/AmplitudeVector.py
@@ -67,7 +67,7 @@ class AmplitudeVector(dict[str, libadcc.Tensor]):
         return self
 
     @property
-    def needs_evaluation(self) -> "bool":
+    def needs_evaluation(self) -> bool:
         return any(t.needs_evaluation for _, t in self.items())
 
     def ones_like(self) -> "AmplitudeVector":
@@ -290,7 +290,7 @@ class AmplitudeVector(dict[str, libadcc.Tensor]):
         if isinstance(other, AmplitudeVector):
             if any(block not in other for block in self.keys()):
                 raise ZeroDivisionError(
-                    "Divisian by zero, since missing blocks are treated as "
+                    "Division by zero, since missing blocks are treated as "
                     f"zero blocks. Self contains {self.blocks}. Other contains "
                     f"{other.blocks}."
                 )
@@ -311,7 +311,7 @@ class AmplitudeVector(dict[str, libadcc.Tensor]):
         if isinstance(other, AmplitudeVector):
             if any(block not in other for block in self.keys()):
                 raise ZeroDivisionError(
-                    "Divisian by zero, since missing blocks are treated as "
+                    "Division by zero, since missing blocks are treated as "
                     f"zero blocks. Self contains {self.blocks}. Other contains "
                     f"{other.blocks}."
                 )

--- a/adcc/tests/AmplitudeVector_test.py
+++ b/adcc/tests/AmplitudeVector_test.py
@@ -20,19 +20,19 @@
 ## along with adcc. If not, see <http://www.gnu.org/licenses/>.
 ##
 ## ---------------------------------------------------------------------
+from numpy.testing import assert_allclose
 import pytest
 import unittest
-import numpy as np
 
-import adcc
+from adcc import AmplitudeVector, LazyMp, AdcMatrix, guess_zero, zeros_like
 from .testdata_cache import testdata_cache
 
 
 class TestAmplitudeVector(unittest.TestCase):
     def test_functionality(self):
-        ground_state = adcc.LazyMp(testdata_cache.refstate("h2o_sto3g", case="gen"))
-        matrix = adcc.AdcMatrix("adc2", ground_state)
-        vectors = [adcc.guess_zero(matrix) for _ in range(2)]
+        ground_state = LazyMp(testdata_cache.refstate("h2o_sto3g", case="gen"))
+        matrix = AdcMatrix("adc2", ground_state)
+        vectors = [guess_zero(matrix) for _ in range(2)]
         for vec in vectors:
             vec.set_random()
         v, w = vectors
@@ -41,9 +41,416 @@ class TestAmplitudeVector(unittest.TestCase):
         with pytest.raises(AttributeError):
             v.pph = w.ph
         # setattr with expression
-        z = adcc.zeros_like(v)
+        z = zeros_like(v)
         z.ph = v.ph + w.ph
         z -= w
-        np.testing.assert_allclose(
+        assert_allclose(
             v.ph.to_ndarray(), z.ph.to_ndarray()
         )
+
+    def test_add(self):
+        adc1 = testdata_cache.adcc_states(
+            system="h2o_sto3g", method="adc1", case="gen", kind="singlet"
+        )
+        adc2 = testdata_cache.adcc_states(
+            system="h2o_sto3g", method="adc2", case="gen", kind="singlet"
+        )
+        #####################
+        # __add__ + __iadd__
+        #####################
+        # - 2 Amplitude vectors
+        # both share the same blocks
+        v1, v2 = adc2.excitation_vector[:2]
+        res = v1 + v2
+        assert res.blocks == ["ph", "pphh"]
+        ref = v1.ph.to_ndarray() + v2.ph.to_ndarray()
+        assert_allclose(res.ph.to_ndarray(), ref, atol=1e-14)
+        ref = v1.pphh.to_ndarray() + v2.pphh.to_ndarray()
+        assert_allclose(res.pphh.to_ndarray(), ref, atol=1e-14)
+        # check in-place addition
+        res_inplace = v1.copy()
+        res_inplace += v2
+        assert_allclose(
+            res.ph.to_ndarray(), res_inplace.ph.to_ndarray(), atol=1e-14
+        )
+        assert_allclose(
+            res.pphh.to_ndarray(), res_inplace.pphh.to_ndarray(), atol=1e-14
+        )
+        # left misses 1 block
+        v1, v2 = adc1.excitation_vector[0], adc2.excitation_vector[0]
+        res = v1 + v2
+        assert res.blocks == ["ph", "pphh"]
+        ref = v1.ph.to_ndarray() + v2.ph.to_ndarray()
+        assert_allclose(res.ph.to_ndarray(), ref, atol=1e-14)
+        assert_allclose(res.pphh.to_ndarray(), v2.pphh.to_ndarray(), atol=1e-14)
+        # check in-place addition
+        res_inplace = v1.copy()
+        res_inplace += v2
+        assert_allclose(
+            res.ph.to_ndarray(), res_inplace.ph.to_ndarray(), atol=1e-14
+        )
+        assert_allclose(
+            res.pphh.to_ndarray(), res_inplace.pphh.to_ndarray(), atol=1e-14
+        )
+        # right misses 1 block
+        v1, v2 = adc2.excitation_vector[0], adc1.excitation_vector[1]
+        res = v1 + v2
+        assert res.blocks == ["ph", "pphh"]
+        ref = v1.ph.to_ndarray() + v2.ph.to_ndarray()
+        assert_allclose(res.ph.to_ndarray(), ref, atol=1e-14)
+        assert_allclose(res.pphh.to_ndarray(), v1.pphh.to_ndarray(), atol=1e-14)
+        # check in-place addition
+        res_inplace = v1.copy()
+        res_inplace += v2
+        assert_allclose(
+            res.ph.to_ndarray(), res_inplace.ph.to_ndarray(), atol=1e-14
+        )
+        assert_allclose(
+            res.pphh.to_ndarray(), res_inplace.pphh.to_ndarray(), atol=1e-14
+        )
+        # - Amplitude + Tensor
+        v1, v2 = adc1.excitation_vector[0], adc1.excitation_vector[1].ph
+        res = v1 + v2
+        assert res.blocks == ["ph"]
+        ref = v1.ph.to_ndarray() + v2.to_ndarray()
+        assert_allclose(res.ph.to_ndarray(), ref, atol=1e-14)
+        # check in-place addition
+        res_inplace = v1.copy()
+        res_inplace += v2
+        assert_allclose(
+            res.ph.to_ndarray(), res_inplace.ph.to_ndarray(), atol=1e-14
+        )
+        # - Amplitude + float
+        v1, v2 = adc2.excitation_vector[0], 0.1
+        res = v1 + v2
+        assert res.blocks == ["ph", "pphh"]
+        ref = v1.ph + v2
+        assert_allclose(res.ph.to_ndarray(), ref.to_ndarray(), atol=1e-14)
+        ref = v1.pphh + v2
+        assert_allclose(res.pphh.to_ndarray(), ref.to_ndarray(), atol=1e-14)
+
+    def test_mul(self):
+        adc1 = testdata_cache.adcc_states(
+            system="h2o_sto3g", method="adc1", case="gen", kind="singlet"
+        )
+        adc2 = testdata_cache.adcc_states(
+            system="h2o_sto3g", method="adc2", case="gen", kind="singlet"
+        )
+        ####################
+        # __mul__ + __imul__
+        ####################
+        # - 2 amplitudes
+        # Both share the same blocks
+        v1, v2 = adc2.excitation_vector[:2]
+        res = v1 * v2
+        assert res.blocks == ["ph", "pphh"]
+        ref = v1.ph.to_ndarray() * v2.ph.to_ndarray()
+        assert_allclose(res.ph.to_ndarray(), ref, atol=1e-14)
+        ref = v1.pphh.to_ndarray() * v2.pphh.to_ndarray()
+        assert_allclose(res.pphh.to_ndarray(), ref, atol=1e-14)
+        # check in-place mul
+        res_inplace = v1.copy()
+        res_inplace *= v2
+        assert_allclose(
+            res.ph.to_ndarray(), res_inplace.ph.to_ndarray(), atol=1e-14
+        )
+        assert_allclose(
+            res.pphh.to_ndarray(), res_inplace.pphh.to_ndarray(), atol=1e-14
+        )
+        # Left amplitude misses a block
+        v1, v2 = adc1.excitation_vector[0], adc2.excitation_vector[0]
+        res = v1 * v2
+        assert res.blocks == ["ph"]
+        ref = v1.ph.to_ndarray() * v2.ph.to_ndarray()
+        assert_allclose(res.ph.to_ndarray(), ref, atol=1e-14)
+        # check in-place mul
+        res_inplace = v1.copy()
+        res_inplace *= v2
+        assert res_inplace.blocks == ["ph"]
+        assert_allclose(
+            res.ph.to_ndarray(), res_inplace.ph.to_ndarray(), atol=1e-14
+        )
+        # Right amplitude misses a block
+        v1, v2 = adc2.excitation_vector[0], adc1.excitation_vector[0]
+        res = v1 * v2
+        assert res.blocks == ["ph"]
+        ref = v1.ph.to_ndarray() * v2.ph.to_ndarray()
+        assert_allclose(res.ph.to_ndarray(), ref, atol=1e-14)
+        # check in-place mul
+        res_inplace = v1.copy()
+        res_inplace *= v2
+        assert res_inplace.blocks == ["ph"]
+        assert_allclose(
+            res.ph.to_ndarray(), res_inplace.ph.to_ndarray(), atol=1e-14
+        )
+        # Amplitude * tensor
+        v1, v2 = adc1.excitation_vector[0], adc1.excitation_vector[1].ph
+        res = v1 * v2
+        assert res.blocks == ["ph"]
+        ref = v1.ph.to_ndarray() * v2.to_ndarray()
+        assert_allclose(res.ph.to_ndarray(), ref, atol=1e-14)
+        # check in-place mul
+        res_inplace = v1.copy()
+        res_inplace *= v2
+        assert res_inplace.blocks == ["ph"]
+        assert_allclose(
+            res.ph.to_ndarray(), res_inplace.ph.to_ndarray(), atol=1e-14
+        )
+        # Amplitude * float
+        v1, v2 = adc1.excitation_vector[0], 0.1
+        res = v1 * v2
+        assert res.blocks == ["ph"]
+        ref = v1.ph * v2
+        assert_allclose(res.ph.to_ndarray(), ref.to_ndarray(), atol=1e-14)
+        # check in-place mul
+        res_inplace = v1.copy()
+        res_inplace *= v2
+        assert res_inplace.blocks == ["ph"]
+        assert_allclose(
+            res.ph.to_ndarray(), res_inplace.ph.to_ndarray(), atol=1e-14
+        )
+
+    def test_div(self):
+        adc1 = testdata_cache.adcc_states(
+            system="h2o_sto3g", method="adc1", case="gen", kind="singlet"
+        )
+        adc2 = testdata_cache.adcc_states(
+            system="h2o_sto3g", method="adc2", case="gen", kind="singlet"
+        )
+        ############################
+        # __truediv__ + __itruediv__
+        ############################
+        # - 2 amplitudes
+        # Both share the same blocks
+        v1, v2 = adc2.excitation_vector[:2]
+        res = v1 / v2
+        assert res.blocks == ["ph", "pphh"]
+        ref = v1.ph / v2.ph
+        assert_allclose(res.ph.to_ndarray(), ref.to_ndarray(), atol=1e-14)
+        ref = v1.pphh / v2.pphh
+        assert_allclose(res.pphh.to_ndarray(), ref.to_ndarray(), atol=1e-14)
+        # check in-place addition
+        res_inplace = v1.copy()
+        res_inplace /= v2
+        assert_allclose(
+            res.ph.to_ndarray(), res_inplace.ph.to_ndarray(), atol=1e-14
+        )
+        assert_allclose(
+            res.pphh.to_ndarray(), res_inplace.pphh.to_ndarray(), atol=1e-14
+        )
+        # Left amplitude misses a block
+        v1, v2 = adc1.excitation_vector[0], adc2.excitation_vector[0]
+        res = v1 / v2
+        assert res.blocks == ["ph"]
+        ref = v1.ph / v2.ph
+        assert_allclose(res.ph.to_ndarray(), ref.to_ndarray(), atol=1e-14)
+        # check in-place div
+        res_inplace = v1.copy()
+        res_inplace /= v2
+        assert res_inplace.blocks == ["ph"]
+        assert_allclose(
+            res.ph.to_ndarray(), res_inplace.ph.to_ndarray(), atol=1e-14
+        )
+        # Right amplitude misses a block
+        v1, v2 = adc2.excitation_vector[0], adc1.excitation_vector[0]
+        with pytest.raises(ZeroDivisionError):
+            res = v1 / v2
+        # check in-place div
+        res_inplace = v1.copy()
+        with pytest.raises(ZeroDivisionError):
+            res_inplace /= v2
+        # Amplitude / tensor
+        v1, v2 = adc1.excitation_vector[0], adc1.excitation_vector[1].ph
+        res = v1 / v2
+        assert res.blocks == ["ph"]
+        ref = v1.ph / v2
+        assert_allclose(res.ph.to_ndarray(), ref.to_ndarray(), atol=1e-14)
+        # check in-place div
+        res_inplace = v1.copy()
+        res_inplace /= v2
+        assert res_inplace.blocks == ["ph"]
+        assert_allclose(
+            res.ph.to_ndarray(), res_inplace.ph.to_ndarray(), atol=1e-14
+        )
+        # Amplitude / float
+        v1, v2 = adc1.excitation_vector[0], 0.1
+        res = v1 / v2
+        assert res.blocks == ["ph"]
+        ref = v1.ph / v2
+        assert_allclose(res.ph.to_ndarray(), ref.to_ndarray(), atol=1e-14)
+        # check in-place div
+        res_inplace = v1.copy()
+        res_inplace /= v2
+        assert res_inplace.blocks == ["ph"]
+        assert_allclose(
+            res.ph.to_ndarray(), res_inplace.ph.to_ndarray(), atol=1e-14
+        )
+
+    def test_sub(self):
+        adc1 = testdata_cache.adcc_states(
+            system="h2o_sto3g", method="adc1", case="gen", kind="singlet"
+        )
+        adc2 = testdata_cache.adcc_states(
+            system="h2o_sto3g", method="adc2", case="gen", kind="singlet"
+        )
+        ####################
+        # __sub__ + __isub__
+        ####################
+        # - 2 amplitudes
+        # Both share the same blocks
+        v1, v2 = adc2.excitation_vector[:2]
+        res = v1 - v2
+        assert res.blocks == ["ph", "pphh"]
+        ref = v1.ph.to_ndarray() - v2.ph.to_ndarray()
+        assert_allclose(res.ph.to_ndarray(), ref, atol=1e-14)
+        ref = v1.pphh.to_ndarray() - v2.pphh.to_ndarray()
+        assert_allclose(res.pphh.to_ndarray(), ref, atol=1e-14)
+        # check in-place subtraction
+        res_inplace = v1.copy()
+        res_inplace -= v2
+        assert res_inplace.blocks == ["ph", "pphh"]
+        assert_allclose(
+            res.ph.to_ndarray(), res_inplace.ph.to_ndarray(), atol=1e-14
+        )
+        assert_allclose(
+            res.pphh.to_ndarray(), res_inplace.pphh.to_ndarray(), atol=1e-14
+        )
+        # Left amplitude misses a block: 0 - x = -x
+        v1, v2 = adc1.excitation_vector[0], adc2.excitation_vector[0]
+        res = v1 - v2
+        assert res.blocks == ["ph", "pphh"]
+        ref = v1.ph.to_ndarray() - v2.ph.to_ndarray()
+        assert_allclose(res.ph.to_ndarray(), ref, atol=1e-14)
+        assert_allclose(res.pphh.to_ndarray(), -v2.pphh.to_ndarray(), atol=1e-14)
+        # check in-place subtraction
+        res_inplace = v1.copy()
+        res_inplace -= v2
+        assert res_inplace.blocks == ["ph", "pphh"]
+        assert_allclose(
+            res.ph.to_ndarray(), res_inplace.ph.to_ndarray(), atol=1e-14
+        )
+        assert_allclose(
+            res.pphh.to_ndarray(), res_inplace.pphh.to_ndarray(), atol=1e-14
+        )
+        # Right amplitude misses a block: x - 0 = x
+        v1, v2 = adc2.excitation_vector[0], adc1.excitation_vector[1]
+        res = v1 - v2
+        assert res.blocks == ["ph", "pphh"]
+        ref = v1.ph.to_ndarray() - v2.ph.to_ndarray()
+        assert_allclose(res.ph.to_ndarray(), ref, atol=1e-14)
+        assert_allclose(res.pphh.to_ndarray(), v1.pphh.to_ndarray(), atol=1e-14)
+        # check in-place subtraction
+        res_inplace = v1.copy()
+        res_inplace -= v2
+        assert res_inplace.blocks == ["ph", "pphh"]
+        assert_allclose(
+            res.ph.to_ndarray(), res_inplace.ph.to_ndarray(), atol=1e-14
+        )
+        assert_allclose(
+            res.pphh.to_ndarray(), res_inplace.pphh.to_ndarray(), atol=1e-14
+        )
+        # - Amplitude - Tensor
+        v1, v2 = adc1.excitation_vector[0], adc1.excitation_vector[1].ph
+        res = v1 - v2
+        assert res.blocks == ["ph"]
+        ref = v1.ph.to_ndarray() - v2.to_ndarray()
+        assert_allclose(res.ph.to_ndarray(), ref, atol=1e-14)
+        # check in-place subtraction
+        res_inplace = v1.copy()
+        res_inplace -= v2
+        assert res_inplace.blocks == ["ph"]
+        assert_allclose(
+            res.ph.to_ndarray(), res_inplace.ph.to_ndarray(), atol=1e-14
+        )
+        # - Amplitude - float
+        v1, v2 = adc2.excitation_vector[0], 0.1
+        res = v1 - v2
+        assert res.blocks == ["ph", "pphh"]
+        ref = v1.ph - v2
+        assert_allclose(res.ph.to_ndarray(), ref.to_ndarray(), atol=1e-14)
+        ref = v1.pphh - v2
+        assert_allclose(res.pphh.to_ndarray(), ref.to_ndarray(), atol=1e-14)
+
+    def test_dot(self):
+        adc1 = testdata_cache.adcc_states(
+            system="h2o_sto3g", method="adc1", case="gen", kind="singlet"
+        )
+        adc2 = testdata_cache.adcc_states(
+            system="h2o_sto3g", method="adc2", case="gen", kind="singlet"
+        )
+        ####################
+        # dot + __matmul__
+        ####################
+        # - 2 amplitudes
+        # Both share the same blocks
+        v1, v2 = adc2.excitation_vector[:2]
+        ref = v1.ph.dot(v2.ph) + v1.pphh.dot(v2.pphh)
+        assert v1.dot(v2) == pytest.approx(ref, abs=1e-14)
+        assert v1 @ v2 == pytest.approx(ref, abs=1e-14)
+        # Left amplitude misses a block
+        v1, v2 = adc1.excitation_vector[0], adc2.excitation_vector[0]
+        ref = v1.ph.dot(v2.ph)
+        assert v1.dot(v2) == pytest.approx(ref, abs=1e-14)
+        assert v1 @ v2 == pytest.approx(ref, abs=1e-14)
+        # Right amplitude misses a block
+        v1, v2 = adc2.excitation_vector[0], adc1.excitation_vector[0]
+        ref = v1.ph.dot(v2.ph)
+        assert v1.dot(v2) == pytest.approx(ref, abs=1e-14)
+        assert v1 @ v2 == pytest.approx(ref, abs=1e-14)
+        # The amplitudes have no block in common
+        v = adc2.excitation_vector[0]
+        v1, v2 = AmplitudeVector(ph=v.ph), AmplitudeVector(pphh=v.pphh)
+        assert v1.dot(v2) == pytest.approx(0.0, abs=1e-14)
+        assert v1 @ v2 == pytest.approx(0.0, abs=1e-14)
+        # - Amplitude and a list of amplitudes
+        # the result has to agree with the individual dot products
+        v1 = adc2.excitation_vector[0]
+        v2 = [
+            adc2.excitation_vector[1], adc1.excitation_vector[0],
+            AmplitudeVector(pphh=v1.pphh)
+        ]
+        ref = [v1.dot(other) for other in v2]
+        assert_allclose(v1.dot(v2), ref, atol=1e-14)
+        assert_allclose(v1 @ v2, ref, atol=1e-14)
+        # an empty list gives an empty array
+        assert len(v1.dot([])) == 0
+
+    def test_reflected_operations(self):
+        adc2 = testdata_cache.adcc_states(
+            system="h2o_sto3g", method="adc2", case="gen", kind="singlet"
+        )
+        ###################################
+        # __radd__ + __rmul__ + __rsub__
+        ###################################
+        # - float + Amplitude
+        v1, v2 = 0.1, adc2.excitation_vector[0]
+        res = v1 + v2
+        assert res.blocks == ["ph", "pphh"]
+        ref = v1 + v2.ph
+        assert_allclose(res.ph.to_ndarray(), ref.to_ndarray(), atol=1e-14)
+        ref = v1 + v2.pphh
+        assert_allclose(res.pphh.to_ndarray(), ref.to_ndarray(), atol=1e-14)
+        # - float * Amplitude
+        res = v1 * v2
+        assert res.blocks == ["ph", "pphh"]
+        ref = v1 * v2.ph
+        assert_allclose(res.ph.to_ndarray(), ref.to_ndarray(), atol=1e-14)
+        ref = v1 * v2.pphh
+        assert_allclose(res.pphh.to_ndarray(), ref.to_ndarray(), atol=1e-14)
+        # - float - Amplitude
+        res = v1 - v2
+        assert res.blocks == ["ph", "pphh"]
+        ref = v1 - v2.ph
+        assert_allclose(res.ph.to_ndarray(), ref.to_ndarray(), atol=1e-14)
+        ref = v1 - v2.pphh
+        assert_allclose(res.pphh.to_ndarray(), ref.to_ndarray(), atol=1e-14)
+        # - Tensor + Amplitude is not supported: the backend operators raise
+        #   a TypeError instead of returning NotImplemented, so the reflected
+        #   operations of the AmplitudeVector are never reached.
+        v1, v2 = adc2.excitation_vector[0].ph, adc2.excitation_vector[0]
+        with pytest.raises(TypeError):
+            v1 + v2
+        with pytest.raises(TypeError):
+            v1 * v2
+        with pytest.raises(TypeError):
+            v1 - v2


### PR DESCRIPTION
This PR refactors the arithmetic operations implemented on the `AmplitudeVector` class such that missing blocks are consistently treated as zero blocks.

Previously, this was only the case for `__add__`, while the other operations employed `__forward_to_blocks`, which raised an exception for differing blocks. Moreover, `dot` showed inconsistent behavior, `ADC1.dot(ADC2)` gave the `ph` overlap, while `ADC2.dot(ADC1)` raised an exception due to a missing `pphh` block. The in-place operators, also employed `__forward_to_blocks`, which created a new `AmplitudeVector` instance and thus were not really in-place.

In this PR I explicitly implemented the arithmetic operations ensuring that inputs and result don't share memory (`libadcc.Tensors` are copied if necessary). Moreover, in-place operations mutate the current instance modifying/deleting existing blocks.
Finally, type hints are introduced throughout `AmplitudeVector.py`

A Note on the reflective operations:
`libadcc.Tensor * Amplitude` (same for other operations) is not possible, since the backend raises a `TypeError`. Thus, `__rmul__` etc. are not reachable for this case and the implementation contains in principle dead code.